### PR TITLE
Localize template to English + language choice at kickoff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 * text=auto
 
-# 큰 원본(발표 자료·녹음·영상)을 Git LFS로 관리하기로 했다면:
-# 1) 각자 `git lfs install` 실행
-# 2) 아래 주석을 해제 (자세한 기준은 _system/UPLOAD_RULES.md)
+# To manage large originals (decks, recordings, video) with Git LFS:
+# 1) everyone runs `git lfs install`
+# 2) uncomment the lines below (see _system/UPLOAD_RULES.md for criteria)
 #*.pdf  filter=lfs diff=lfs merge=lfs -text
 #*.pptx filter=lfs diff=lfs merge=lfs -text
 #*.docx filter=lfs diff=lfs merge=lfs -text

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,16 @@
-# CODEOWNERS — 보호 파일 규칙의 실제 강제 장치
+# CODEOWNERS — the actual enforcement for protected files
 #
-# 사용법:
-# 1. 아래 @integrator-id 를 통합 책임자(또는 팀장)의 GitHub ID로 바꿉니다.
-# 2. 각 줄 앞의 주석(#)을 지웁니다.
-# 3. GitHub Settings > Branches 에서 main 보호 규칙을 만들고
-#    "Require review from Code Owners"를 켭니다.
-# 이 세 가지가 모두 되어야 INTEGRATION_RULES.md의 보호 파일 규칙이 실제로 강제됩니다.
+# How to use:
+# 1. Replace @integrator-id below with the integrator's (or lead's) GitHub ID.
+# 2. Remove the leading # from each rule line.
+# 3. In GitHub Settings > Branches, create a protection rule for main and
+#    enable "Require review from Code Owners".
+# All three are needed before the protected-file rules in INTEGRATION_RULES.md are enforced.
 #
 # /000\ HOME.md       @integrator-id
 # /AGENTS.md          @integrator-id
 # /CLAUDE.md          @integrator-id
+# /ONBOARDING.md      @integrator-id
 # /TEAM-GUIDE.md      @integrator-id
 # /_system/           @integrator-id
 # /02\ Decisions/     @integrator-id

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
-## 무엇을 바꿨나요?
+## What changed?
 
-## 근거/원본
+## Evidence / originals
 
-## 기존 결정과 충돌하나요?
-- [ ] 아니오
-- [ ] 예 — 관련 ADR/CURRENT_STATE와 필요한 결정:
+## Does this conflict with an existing decision?
+- [ ] No
+- [ ] Yes — related ADR/CURRENT_STATE and the decision needed:
 
-## 체크
-- [ ] 원본은 `_raw/`에 보관했다.
-- [ ] Markdown 정리본에 원본 경로를 적었다.
-- [ ] Inbox에서 분류했다면 `00 Inbox/INTAKE_INDEX.md` 상태와 최종 위치를 갱신했다.
-- [ ] 보호 파일을 바꾸지 않았다. (바꿨다면 통합 PR이다.)
+## Checklist
+- [ ] Originals are stored in `_raw/`.
+- [ ] The Markdown digest names its original's path.
+- [ ] If filing from the Inbox, `00 Inbox/INTAKE_INDEX.md` status and final location are updated.
+- [ ] No protected files changed. (If they did, this is an integration PR.)

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .obsidian/workspace-mobile.json
 *.tmp
 
-# 민감 연락처 등 로컬 전용 파일 (_system/KICKOFF_INTERVIEW.md 참고)
+# local-only files such as sensitive contacts (see _system/KICKOFF_INTERVIEW.md)
 *.local.md

--- a/00 Inbox/INTAKE_INDEX.md
+++ b/00 Inbox/INTAKE_INDEX.md
@@ -1,21 +1,21 @@
-# INTAKE_INDEX — Inbox 처리 대장
+# INTAKE_INDEX — Inbox ledger
 
-> `00 Inbox/`는 임시 쓰레기통이 아닙니다. **분류 대기열**입니다. 항목이 이동되어도 Git 이력과 원본은 남습니다.
+> `00 Inbox/` is not a temporary trash can. It is a **triage queue**. Even after items move on, Git history and the originals remain.
 
-| 접수일 | 항목 | 상태 | 원본 경로 | 정리본/이동 위치 | 담당 | 비고 |
+| Received | Item | Status | Original path | Digest/destination | Owner | Notes |
 |---|---|---|---|---|---|---|
-| YYYY-MM-DD | [자료 이름] | untriaged | `_raw/...` | - | [id] | - |
+| YYYY-MM-DD | [item name] | untriaged | `_raw/...` | - | [id] | - |
 
-## 상태
+## Statuses
 
-- `untriaged`: 아직 분류하지 않음
-- `classified`: `01~07` 폴더로 `git mv` 완료. 이 행에 최종 위치를 적음
-- `hold`: 보류. 이유와 다음 검토일을 비고에 적음
-- `archived`: 더 이상 활성 맥락은 아니지만 `90 Archive/`에 보관
+- `untriaged`: not yet sorted
+- `classified`: moved to a `01–07` folder with `git mv`; the row records the final location
+- `hold`: parked; the reason and next review date go in Notes
+- `archived`: no longer active context, kept in `90 Archive/`
 
-## 처리 원칙
+## Principles
 
-1. 자료를 받으면 원본을 먼저 `00 Inbox/_raw/`에 넣고 이 대장에 한 줄을 추가합니다.
-2. 분류할 때는 삭제 대신 `git mv`로 목적 폴더 또는 그 폴더의 `_raw/`로 이동합니다.
-3. PDF·PPT·Word·녹음은 원본을 옮긴 뒤 Markdown 정리본을 같은 목적 폴더에 추가합니다.
-4. `00 Inbox/`의 활성 목록이 비는 것은 **처리 완료**를 뜻할 뿐, 자료가 사라졌다는 뜻이 아닙니다.
+1. When material arrives, put the original in `00 Inbox/_raw/` first and add a row here.
+2. File by moving with `git mv` to the destination folder (or its `_raw/`) — never by deleting.
+3. For PDF/PPT/Word/recordings, move the original first, then add a Markdown digest in the same destination folder.
+4. An empty active list in `00 Inbox/` means **processing is done** — not that material disappeared.

--- a/00 Inbox/README.md
+++ b/00 Inbox/README.md
@@ -1,3 +1,3 @@
 # Inbox
 
-아직 분류하지 않은 자료를 둡니다. 접수하면 `INTAKE_INDEX.md`에 먼저 기록합니다. 원본은 `_raw/`에 두고, 분류할 때는 삭제가 아닌 `git mv`로 목적 폴더에 옮깁니다.
+Unsorted material lands here. Log every intake in `INTAKE_INDEX.md` first. Keep originals in `_raw/`, and when filing, move items to their destination folder with `git mv` instead of deleting.

--- a/00 Project Hub/README.md
+++ b/00 Project Hub/README.md
@@ -1,22 +1,22 @@
-# 00 Project Hub — 저장소 전체 지도
+# 00 Project Hub — Map of the repository
 
-> `000 HOME.md`가 **지금 무엇을 해야 하는지** 알려준다면, 이 파일은 **자료가 어디에 있는지** 알려줍니다.
+> `000 HOME.md` tells you **what to do right now**; this file tells you **where things live**.
 
-| 찾는 것 | 위치 |
+| Looking for | Location |
 |---|---|
-| 현재 목표·막힌 일·다음 행동 | `_system/CURRENT_STATE.md` |
-| 확정된 선택과 이유 | `_system/DECISION_LOG.md`, `02 Decisions/` |
-| 팀 구성·담당 | `_system/TEAM.md`, `06 Team/` |
-| 팀 규범 (회의·소통·의사결정) | `_system/WORKING_AGREEMENTS.md` |
-| 처음 시작할 때 온보딩·킥오프 | `ONBOARDING.md`, `_system/KICKOFF_INTERVIEW.md` |
-| 아직 분류하지 않은 자료 | `00 Inbox/`, `00 Inbox/INTAKE_INDEX.md` |
-| 회의 근거 | `01 Meetings/` |
-| 리서치와 원본 | `03 Research/` 및 각 폴더의 `_raw/` |
-| 개인 작업 기록 | `04 Worklogs/` |
-| 공식 할 일 | `05 Tasks/` |
-| 산출물 | `07 Outputs/` |
+| Current goal, blockers, next actions | `_system/CURRENT_STATE.md` |
+| Confirmed choices and reasons | `_system/DECISION_LOG.md`, `02 Decisions/` |
+| Team makeup and ownership | `_system/TEAM.md`, `06 Team/` |
+| Team norms (meetings, comms, decisions) | `_system/WORKING_AGREEMENTS.md` |
+| Getting-started onboarding & kickoff | `ONBOARDING.md`, `_system/KICKOFF_INTERVIEW.md` |
+| Unsorted material | `00 Inbox/`, `00 Inbox/INTAKE_INDEX.md` |
+| Meeting evidence | `01 Meetings/` |
+| Research and originals | `03 Research/` and each folder's `_raw/` |
+| Personal work logs | `04 Worklogs/` |
+| Official to-dos | `05 Tasks/` |
+| Deliverables | `07 Outputs/` |
 
-## 사용 규칙
-- 새 파일을 만들기 전에 위 표에서 목적에 맞는 위치를 확인합니다.
-- 팀 공통 파일의 위치를 바꾸면 `000 HOME.md`와 이 지도를 함께 갱신합니다.
-- 원본 파일은 삭제하지 않고 해당 폴더의 `_raw/` 아래에 둡니다.
+## Rules
+- Before creating a new file, check this table for the right location.
+- If a shared file moves, update `000 HOME.md` and this map together.
+- Never delete originals; keep them under the folder's `_raw/`.

--- a/000 HOME.md
+++ b/000 HOME.md
@@ -1,24 +1,24 @@
-# 000 HOME — 프로젝트 대시보드
+# 000 HOME — Project dashboard
 
-> 새 팀원과 AI는 **이 파일부터** 읽습니다. 다음으로 `AGENTS.md`, `_system/CURRENT_STATE.md`, `_system/DECISION_LOG.md`를 읽습니다.
+> New teammates and AI read **this file first**, then `AGENTS.md`, `_system/CURRENT_STATE.md`, and `_system/DECISION_LOG.md`.
 
-## 한 줄 목표
-- **프로젝트:** [프로젝트 이름]
-- **문제:** [누구의 어떤 문제를 푸는가]
-- **현재 단계:** [리서치 / 기획 / 제작 / 검증 / 발표]
+## One-line goal
+- **Project:** [project name]
+- **Problem:** [whose problem, and what is it]
+- **Current phase:** [research / planning / building / validating / presenting]
 
-## 지금 가장 중요한 것
-1. [이번 주 우선순위]
-2. [막힌 일]
-3. [다음 마감]
+## What matters most right now
+1. [this week's priority]
+2. [what's blocked]
+3. [next deadline]
 
-## 읽는 지도
-- 처음 시작(온보딩·킥오프): `ONBOARDING.md`, `_system/KICKOFF_INTERVIEW.md`
-- 현재 상태: `_system/CURRENT_STATE.md`
-- 확정된 결정: `_system/DECISION_LOG.md`, `02 Decisions/`
-- 팀과 역할: `_system/TEAM.md`
-- 팀 규범: `_system/WORKING_AGREEMENTS.md`
-- 공통 용어: `_system/GLOSSARY.md`
-- 저장소 전체 지도: `00 Project Hub/README.md`
-- 원본/Markdown 처리: `_system/UPLOAD_RULES.md`
-- 파일·브랜치 규칙: `_system/PROJECT_RULES.md`, `_system/INTEGRATION_RULES.md`
+## Reading map
+- Getting started (onboarding & kickoff): `ONBOARDING.md`, `_system/KICKOFF_INTERVIEW.md`
+- Current state: `_system/CURRENT_STATE.md`
+- Confirmed decisions: `_system/DECISION_LOG.md`, `02 Decisions/`
+- Team and roles: `_system/TEAM.md`
+- Team norms: `_system/WORKING_AGREEMENTS.md`
+- Shared glossary: `_system/GLOSSARY.md`
+- Repository map: `00 Project Hub/README.md`
+- Originals / Markdown handling: `_system/UPLOAD_RULES.md`
+- File and branch rules: `_system/PROJECT_RULES.md`, `_system/INTEGRATION_RULES.md`

--- a/01 Meetings/README.md
+++ b/01 Meetings/README.md
@@ -1,3 +1,3 @@
 # Meetings
 
-날짜별 회의록을 둡니다. 결정 후보는 회의록에, 확정된 결정은 `02 Decisions/` ADR에 기록합니다.
+Dated meeting notes live here. Decision candidates stay in the notes; confirmed decisions become ADRs in `02 Decisions/`.

--- a/02 Decisions/README.md
+++ b/02 Decisions/README.md
@@ -1,3 +1,3 @@
 # Decisions
 
-공식 결정은 ADR 형식으로 보관합니다. 통합 책임자만 추가·수정합니다.
+Official decisions are kept in ADR form. Only the integrator adds or edits them.

--- a/03 Research/README.md
+++ b/03 Research/README.md
@@ -1,3 +1,3 @@
 # Research
 
-조사·기사·인터뷰·PDF/PPT/Word 정리본을 둡니다. 원본은 `_raw/`, Markdown 정리본은 이 폴더에 둡니다.
+Research, articles, interviews, and Markdown digests of PDF/PPT/Word files. Originals go in `_raw/`; digests sit in this folder.

--- a/04 Worklogs/README.md
+++ b/04 Worklogs/README.md
@@ -1,3 +1,3 @@
 # Worklogs
 
-개인 작업의 사실·변경·막힌 점을 날짜별로 기록합니다.
+Dated records of personal work: facts, changes, blockers.

--- a/05 Tasks/README.md
+++ b/05 Tasks/README.md
@@ -1,3 +1,3 @@
 # Tasks
 
-공식 우선순위와 할 일입니다. 통합 책임자만 변경합니다.
+The official priorities and to-dos. Only the integrator changes them.

--- a/06 Team/README.md
+++ b/06 Team/README.md
@@ -1,9 +1,9 @@
-# 06 Team — 팀원별 담당과 AI 프롬프트
+# 06 Team — Per-member ownership and AI prompts
 
-팀원별 담당 범위, 작업 방식, 그리고 각자가 사용하는 AI 프롬프트를 둡니다.
+Each member's scope, working style, and the AI prompts they use.
 
-- 개인 파일: `06 Team/<별칭>.md`
-- 공통 규칙: 루트의 `AGENTS.md`
-- 공식 역할·권한: `_system/TEAM.md`
+- Personal file: `06 Team/<alias>.md`
+- Shared rules: `AGENTS.md` at the root
+- Official roles and rights: `_system/TEAM.md`
 
-개인 프롬프트는 공통 규칙을 복제하지 말고, 담당 업무와 필요한 맥락만 추가합니다.
+Personal prompts add only member-specific duties and context — don't duplicate the shared rules.

--- a/07 Outputs/README.md
+++ b/07 Outputs/README.md
@@ -1,3 +1,3 @@
 # Outputs
 
-기획서, 발표, 데모 설명, 최종 산출물을 둡니다.
+Plans, presentations, demo notes, and final deliverables.

--- a/90 Archive/README.md
+++ b/90 Archive/README.md
@@ -1,3 +1,3 @@
 # Archive
 
-종료되었거나 더 이상 현재 맥락에 필요하지 않은 자료를 보관합니다.
+Closed work and material no longer part of the active context.

--- a/99 Templates/adr.md
+++ b/99 Templates/adr.md
@@ -1,12 +1,12 @@
-# ADR-NNNN — 결정 제목
+# ADR-NNNN — Decision title
 
-- 날짜:
-- 상태: 제안 | 확정 | 대체됨
+- Date:
+- Status: proposed | confirmed | superseded
 
-## 맥락
+## Context
 
-## 결정
+## Decision
 
-## 이유와 근거
+## Rationale and evidence
 
-## 영향
+## Consequences

--- a/99 Templates/meeting.md
+++ b/99 Templates/meeting.md
@@ -1,12 +1,12 @@
-# YYYY-MM-DD 회의 제목
+# YYYY-MM-DD Meeting title
 
-- 일시:
-- 참석:
-- 원본/녹음:
+- When:
+- Attendees:
+- Original/recording:
 
-## 논의
+## Discussion
 
-## 결정 후보 (아직 확정 아님)
+## Decision candidates (not confirmed yet)
 
-## 다음 행동
-- [ ] 담당자 — 할 일
+## Next actions
+- [ ] owner — task

--- a/99 Templates/member.md
+++ b/99 Templates/member.md
@@ -1,21 +1,21 @@
-# [별칭] — 팀원 프로필
+# [alias] — Member profile
 
 - GitHub: [id]
-- 주 연락 채널: [Discord/Slack/...] (급할 때: [채널])
-- 응답 기대: [예: 24시간 안]
+- Primary channel: [Discord/Slack/...] (urgent: [channel])
+- Response time: [e.g., within 24 hours]
 
-## 잘하는 것 / 장점
-- [예: 발표, 디자인, 데이터 분석]
+## Strengths
+- [e.g., presenting, design, data analysis]
 
-## 맡은 역할
-- [담당 범위]
+## Role
+- [scope]
 
-## 배우고 싶은 것 (개인 목표)
-- [이 프로젝트에서 얻고 싶은 것]
+## Wants to learn (personal goal)
+- [what they want out of this project]
 
-## 가용 시간
-- 주당 약 [N]시간
-- 안 되는 시간대: [예: 화·목 저녁, 중간고사 기간]
+## Availability
+- ~[N] hours per week
+- Blocked slots: [e.g., Tue/Thu evenings, midterm weeks]
 
-## 작업 방식 메모
-- [예: 밤에 집중이 잘 됨, 텍스트보다 그림으로 소통 선호]
+## Working-style notes
+- [e.g., focuses best at night, prefers diagrams over text]

--- a/99 Templates/research.md
+++ b/99 Templates/research.md
@@ -1,11 +1,11 @@
-# YYYY-MM-DD 리서치 제목
+# YYYY-MM-DD Research title
 
-> 원본: _raw/원본파일.pdf 또는 URL
+> Origin: _raw/original-file.pdf or URL
 
-## 질문
+## Question
 
-## 사실/근거
+## Facts / evidence
 
-## 해석
+## Interpretation
 
-## 프로젝트에 주는 영향
+## Impact on the project

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,26 @@
-# AGENTS.md — 사람과 AI의 공통 규칙
+# AGENTS.md — Shared rules for humans and AI
 
-## 시작 게이트 — 킥오프 인터뷰
-`_system/KICKOFF_INTERVIEW.md`의 첫 줄 `상태:`가 `대기`이면, 다른 요청을 처리하기 전에 팀장에게 킥오프 인터뷰를 제안하고 그 파일의 진행 규칙대로 실행한다. 완료하면 그 파일의 상태를 `완료 (YYYY-MM-DD)`로 바꾼다. 팀장이 미루면 강요하지 않되, 새 세션에서 한 번씩만 다시 안내한다.
+## Start gate — kickoff interview
+If the `Status:` line at the top of `_system/KICKOFF_INTERVIEW.md` says `pending`, propose the kickoff interview to the team lead before handling any other request, and run it by that file's rules. When finished, set the status to `done (YYYY-MM-DD)`. If the lead defers, don't push — remind once per new session.
 
-## 반드시 먼저 읽을 것
+## Working language
+The template ships in English. The kickoff interview asks for the team's working language and records it in `_system/KICKOFF_INTERVIEW.md`. Hold all conversation and write all generated notes and summaries in that language; keep file names, folder structure, and status keywords (`pending` / `done`) in English.
+
+## Read these first
 1. `000 HOME.md`
 2. `_system/CURRENT_STATE.md`
 3. `_system/DECISION_LOG.md`
-4. 요청과 직접 관련 있는 폴더의 문서
+4. Documents in the folders directly relevant to the request
 
-## 작업 규칙
-- 확인되지 않은 사실·결정·수치를 지어내지 않는다. 모르면 `_system/CURRENT_STATE.md`의 미해결 항목 또는 질문으로 남긴다.
-- PDF·PPT·Word·녹음 원본을 지우지 않는다. `_raw/`에 원본을 보관하고, 읽기 쉬운 Markdown 정리본을 같은 폴더에 둔다.
-- 작업 전후에 자신의 작업 기록을 `04 Worklogs/`에 남긴다.
-- 팀원 브랜치에서는 근거·초안·산출물만 다룬다. `_system/`, `02 Decisions/`, `05 Tasks/`, 최상위 안내 파일은 통합 책임자만 바꾼다.
-- AI가 만든 글·코드·요약은 출처와 가정을 함께 적고 사람이 검토할 수 있게 둔다.
+## Working rules
+- Never invent unverified facts, decisions, or numbers. If unsure, leave it as an open item or question in `_system/CURRENT_STATE.md`.
+- Never delete PDF/PPT/Word/recording originals. Keep originals in `_raw/` and put a readable Markdown digest in the same folder.
+- Log your own work in `04 Worklogs/` before and after working.
+- Member branches touch only evidence, drafts, and outputs. Only the integrator changes `_system/`, `02 Decisions/`, `05 Tasks/`, and the top-level guide files.
+- Anything AI produces — text, code, summaries — ships with its sources and assumptions, left for a human to review.
 
-## AI 프로토타입 작업
-AI에게 구현을 맡길 때는 이 저장소를 먼저 읽게 한 뒤, 현재 목표·결정·제약을 근거로 Claude Code/Claude Design용 프롬프트를 작성하거나 구현한다.
+## AI prototype work
+When handing implementation to AI, have it read this repository first, then write or implement Claude Code / Claude Design prompts grounded in the current goal, decisions, and constraints.
 
-## 우선순위
-사람의 직접 지시 > 이 파일의 공통 규칙 > AI 기본 동작
+## Priority
+Direct human instructions > shared rules in this file > AI defaults

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-# CLAUDE.md — Claude Code 진입점
+# CLAUDE.md — Claude Code entry point
 
-이 저장소의 사람·AI 공통 규칙은 `AGENTS.md` 한 곳에서 관리합니다. 아래 임포트로 같은 규칙을 읽습니다.
+The shared rules for this repository live in `AGENTS.md`. The import below loads the same rules.
 
 @AGENTS.md

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,55 +1,55 @@
-# ONBOARDING — 팀이 처음 시작하는 순서
+# ONBOARDING — How a team gets started
 
-> 목표: 이틀 안에 전원이 같은 맥락 위에서 첫 작업을 시작합니다.
-> 팀장은 0·1단계, 팀원은 2단계, 전원이 3단계를 진행합니다.
+> Goal: within two days, everyone starts their first task on the same context.
+> The lead runs steps 0–1, members run step 2, everyone runs step 3.
 
-## 진행 체크
+## Progress check
 
-| 단계 | 담당 | 예상 시간 | 완료 기준 |
+| Step | Owner | Time | Done when |
 |---|---|---:|---|
-| 0. 저장소 준비 | 팀장 | 10분 | Private 생성 + 팀원 전원 초대 |
-| 1. 킥오프 인터뷰 | 팀장 + AI | 20분 | `KICKOFF_INTERVIEW.md` 상태 `완료`, 공식 문서 채워짐 |
-| 2. 팀원 합류 | 각 팀원 | 15분 | 각자 온보딩 PR 머지 |
-| 3. 첫 회의 | 전원 | 30분 | 팀 규범 확정 + 다음 할 일 Top 3 확정 |
+| 0. Repo setup | Lead | 10 min | Private repo created + all members invited |
+| 1. Kickoff interview | Lead + AI | 20 min | `KICKOFF_INTERVIEW.md` status `done`, official docs filled |
+| 2. Members join | Each member | 15 min | Each member's onboarding PR merged |
+| 3. First meeting | Everyone | 30 min | Working agreements confirmed + top-3 next tasks set |
 
-## 0단계 — 저장소 준비 (팀장)
+## Step 0 — Repo setup (lead)
 
-1. **Use this template**으로 팀 저장소를 만들되, 반드시 **Private**을 선택합니다.
-   - 팀 저장소에는 연락 핸들, 회의록, 확정 전 아이디어, 갈등 기록까지 쌓입니다. **항상 프라이빗으로 운영**하고, 포트폴리오 공개는 프로젝트가 끝난 뒤 민감 정보를 정리하고 나서 결정하세요.
-   - GitHub 무료 플랜도 Private 저장소에 협업자를 제한 없이 초대할 수 있습니다.
-2. Settings → Collaborators에서 팀원 전원을 **Write** 권한으로 초대합니다.
-3. Settings → Branches에서 `main` 보호 규칙을 만들고 required review를 켭니다. `.github/CODEOWNERS`의 주석을 해제하고 통합 책임자 ID를 넣으면 보호 파일 규칙이 실제로 강제됩니다.
-4. Actions 탭에서 워크플로가 활성인지 확인합니다 (주간 Branch audit).
+1. Create the team repository with **Use this template**, and make sure to pick **Private**.
+   - The repository accumulates contact handles, meeting notes, unconfirmed ideas, even conflict records. **Always run it private**; consider going public only after the project ends and sensitive content has been scrubbed.
+   - GitHub's free plan allows unlimited collaborators on private repositories.
+2. In Settings → Collaborators, invite every member with **Write** access.
+3. In Settings → Branches, add a protection rule for `main` and require reviews. Uncomment `.github/CODEOWNERS` and fill in the integrator's ID to actually enforce the protected-file rules.
+4. Check the Actions tab to confirm workflows are enabled (weekly Branch audit).
 
-## 1단계 — 킥오프 인터뷰 (팀장 + AI)
+## Step 1 — Kickoff interview (lead + AI)
 
-1. 저장소를 클론하고 Claude Code·Codex 같은 AI 도구로 엽니다.
-2. `AGENTS.md`의 시작 게이트가 킥오프 인터뷰를 시작합니다. 팀 구성·연락처·특기·팀 규범·목표를 답하면 AI가 `_system/TEAM.md`, `_system/WORKING_AGREEMENTS.md`, `000 HOME.md`, `_system/CURRENT_STATE.md`, `06 Team/*`를 채웁니다.
-3. AI 없이 진행한다면 `_system/KICKOFF_INTERVIEW.md`의 질문 5묶음을 보고 같은 파일들을 직접 채웁니다.
-4. 결과를 커밋·푸시합니다. 이 시점의 팀 규범과 팀원 프로필은 **초안**입니다 — 확정은 3단계에서 합니다.
+1. Clone the repository and open it with an AI tool like Claude Code or Codex.
+2. The start gate in `AGENTS.md` launches the kickoff interview. It first asks for the team's working language, then walks through team makeup, contacts, strengths, team norms, and goals, and fills `_system/TEAM.md`, `_system/WORKING_AGREEMENTS.md`, `000 HOME.md`, `_system/CURRENT_STATE.md`, and `06 Team/*`.
+3. Without AI, walk through the question groups in `_system/KICKOFF_INTERVIEW.md` and fill the same files yourself.
+4. Commit and push the result. Team norms and member profiles are **drafts** at this point — they get confirmed in step 3.
 
-## 2단계 — 팀원 합류 (각자)
+## Step 2 — Members join (each member)
 
-첫 PR을 미리 연습하는 리허설을 겸합니다. Git이 처음이면 `TEAM-GUIDE.md`를 옆에 두고 진행하세요.
+This doubles as a rehearsal of your first PR. New to Git? Keep `TEAM-GUIDE.md` open beside you.
 
-1. 초대를 수락하고 저장소를 클론합니다.
-2. `000 HOME.md` → `_system/WORKING_AGREEMENTS.md`(초안) → `06 Team/<내 별칭>.md` 순서로 읽습니다. (10분)
-3. `member/<이름>-onboarding` 브랜치를 만듭니다.
-4. 팀장이 채워 둔 내 프로필(`06 Team/<내 별칭>.md`)을 본인이 직접 검토·보완합니다 — 특기, 가용 시간, 배우고 싶은 것.
-5. `04 Worklogs/YYYY-MM-DD-<별칭>.md`에 한 줄을 남깁니다: 온보딩 완료 사실과, 규범 초안에 대한 의견이 있으면 한 줄.
-6. PR을 열어 팀장 리뷰를 받아 머지합니다. **이 PR이 머지되면 온보딩 완료입니다.**
+1. Accept the invite and clone the repository.
+2. Read in order: `000 HOME.md` → `_system/WORKING_AGREEMENTS.md` (draft) → `06 Team/<your-alias>.md`. (10 min)
+3. Create a `member/<name>-onboarding` branch.
+4. Review and improve your own profile (`06 Team/<your-alias>.md`) that the lead drafted — strengths, availability, what you want to learn.
+5. Add one line to `04 Worklogs/YYYY-MM-DD-<alias>.md`: that you finished onboarding, plus one line of feedback on the norms draft if you have any.
+6. Open a PR and get the lead's review and merge. **When this PR merges, your onboarding is done.**
 
-## 3단계 — 첫 회의 (전원)
+## Step 3 — First meeting (everyone)
 
-1. `_system/WORKING_AGREEMENTS.md` 초안을 함께 읽고 수정·확정합니다. 온보딩 PR에 남긴 의견을 여기서 다룹니다.
-2. 확정하면 `_system/DECISION_LOG.md`에 "팀 규범 v1 확정"으로 기록합니다.
-3. `_system/CURRENT_STATE.md`의 다음 할 일 Top 3와 담당을 확정합니다.
-4. 회의록은 `99 Templates/meeting.md` 양식으로 `01 Meetings/YYYY-MM-DD-킥오프.md`에 남깁니다.
+1. Read `_system/WORKING_AGREEMENTS.md` together; revise and confirm it. Address feedback left in onboarding PRs here.
+2. Once confirmed, record "team norms v1 confirmed" in `_system/DECISION_LOG.md`.
+3. Confirm the top-3 next tasks and their owners in `_system/CURRENT_STATE.md`.
+4. Save the meeting notes as `01 Meetings/YYYY-MM-DD-kickoff.md` using `99 Templates/meeting.md`.
 
-## 완료 판정
+## Definition of done
 
-- [ ] 저장소 Private + 전원 초대·클론 완료
-- [ ] `KICKOFF_INTERVIEW.md` 상태 `완료`
-- [ ] 팀원 수만큼 온보딩 PR 머지
-- [ ] `WORKING_AGREEMENTS.md` 확정 + `DECISION_LOG.md` 기록
-- [ ] `CURRENT_STATE.md`에 다음 할 일 Top 3
+- [ ] Repo private + everyone invited and cloned
+- [ ] `KICKOFF_INTERVIEW.md` status `done`
+- [ ] One onboarding PR merged per member
+- [ ] `WORKING_AGREEMENTS.md` confirmed + logged in `DECISION_LOG.md`
+- [ ] Top-3 next tasks in `CURRENT_STATE.md`

--- a/README.md
+++ b/README.md
@@ -1,80 +1,80 @@
 # Context Hippo 🦛
 
 <p align="center">
-  <img src="assets/context-hippo-hero.png" alt="입을 크게 벌린 검은 하마 — Context Hippo 마크" width="380" />
+  <img src="assets/context-hippo-hero.png" alt="Context Hippo mark — a black hippo with its mouth wide open" width="380" />
 </p>
 
-팀의 흩어진 대화·회의·링크·문서를 받아, 사람과 AI가 함께 읽을 수 있는 **공유 맥락으로 소화하는** Obsidian + GitHub 템플릿입니다.
+An Obsidian + GitHub template that takes your team's scattered chats, meetings, links, and documents and **digests them into shared context** that humans and AI read together.
 
-Context Hippo는 자동으로 모든 자료를 처리하는 서비스가 아닙니다. 대신 원본을 어디에 넣고, 무엇을 Markdown으로 정리하며, 어떤 내용을 공식 결정과 현재 상태로 남길지 정합니다. 사람과 AI는 그 규칙을 함께 읽고 같은 프로젝트 맥락에서 작업합니다.
+Context Hippo is not a service that processes everything automatically. Instead, it defines where raw material goes, what gets digested into Markdown, and what becomes official decisions and current state. Humans and AI read the same rules and work from the same project context.
 
-## 작동 방식
+## How it works
 
-### 1. Capture — 원본을 모읍니다
-회의 전사, 링크, PDF·PPT·Word, 사진, 메모처럼 아직 정리되지 않은 것은 `00 Inbox/`에 넣습니다. 원본은 각 작업 폴더의 `_raw/`에 보관합니다.
+### 1. Capture — collect the raw material
+Anything not yet organized — meeting transcripts, links, PDF/PPT/Word files, photos, notes — goes into `00 Inbox/`. Originals are kept in each working folder's `_raw/`.
 
-### 2. Digest — 읽을 수 있는 Markdown으로 소화합니다
-사람 또는 AI가 원본을 Markdown 노트로 정리하고, 내용의 성격에 따라 회의·리서치·작업 로그·산출물 폴더로 옮깁니다. 정리본은 항상 원본 위치를 가리킵니다.
+### 2. Digest — turn it into readable Markdown
+A human or AI organizes the original into a Markdown note and files it under meetings, research, worklogs, or outputs depending on its nature. The digest always points back to the original.
 
-### 3. Decide — 공식 맥락을 갱신합니다
-확정된 선택은 `02 Decisions/`와 `_system/DECISION_LOG.md`에, 지금 진행 중인 일과 막힌 일은 `_system/CURRENT_STATE.md`에 남깁니다. 이 파일들이 팀의 공식 기준점입니다.
+### 3. Decide — update the official context
+Confirmed choices go to `02 Decisions/` and `_system/DECISION_LOG.md`; work in progress and blockers go to `_system/CURRENT_STATE.md`. These files are the team's official baseline.
 
-### 4. Reuse — 다음 사람과 AI가 바로 이어받습니다
-새 팀원과 AI는 `000 HOME.md`부터 읽습니다. 볼트 전체를 훑지 않고도 현재 목표·결정·규칙·다음 행동을 파악한 뒤, 필요한 근거만 더 읽을 수 있습니다.
+### 4. Reuse — the next person or AI picks up instantly
+New teammates and AI start from `000 HOME.md`. Without scanning the whole vault, they get the current goal, decisions, rules, and next actions, then read only the evidence they need.
 
-## 시작하기
+## Getting started
 
-1. 이 저장소를 **Use this template**으로 복제하되, 팀 저장소는 **반드시 Private**으로 만듭니다. 연락처·회의록·확정 전 아이디어가 쌓이는 공간입니다 — 이 템플릿 저장소는 공개지만, 여러분의 팀 저장소는 항상 프라이빗으로 운영하고 공개는 프로젝트 종료 후 정리해서 결정하세요.
-2. `ONBOARDING.md` 순서대로 진행합니다: 팀장이 저장소를 준비하고(0단계), AI와 **킥오프 인터뷰**(`_system/KICKOFF_INTERVIEW.md`)로 공식 문서를 채운 뒤(1단계), 팀원들이 온보딩 PR로 합류하고(2단계), 첫 회의에서 팀 규범을 확정합니다(3단계).
-3. 클론한 폴더를 Claude Code·Codex 같은 AI 도구로 열면 `AGENTS.md`의 시작 게이트가 킥오프 인터뷰를 자동으로 시작합니다. AI 없이 쓴다면 `000 HOME.md`, `_system/TEAM.md`, `_system/CURRENT_STATE.md`의 대괄호 내용을 직접 채웁니다.
-4. 자료는 `00 Inbox/`에, 팀원별 작업은 `member/<이름>-<작업>` 브랜치에 올립니다.
-5. 팀장/통합 책임자가 PR을 검토해 `integrate/<범위>-YYYY-MM-DD`로 모은 뒤 `main`에 반영합니다.
+1. Create your team repository with **Use this template** — and make it **Private**. Contact handles, meeting notes, and unconfirmed ideas accumulate here. This template repository is public, but your team repository should always run private; consider going public only after the project ends and sensitive content has been scrubbed.
+2. Follow `ONBOARDING.md`: the lead prepares the repository (step 0), fills the official docs through the AI **kickoff interview** (`_system/KICKOFF_INTERVIEW.md`, step 1), teammates join via onboarding PRs (step 2), and the first meeting locks in the team agreements (step 3).
+3. Open the cloned folder with an AI tool like Claude Code or Codex and the start gate in `AGENTS.md` launches the kickoff interview automatically — it first asks for your team's working language (English, Korean, or any other). Working without AI? Fill in the bracketed placeholders in `000 HOME.md`, `_system/TEAM.md`, and `_system/CURRENT_STATE.md` yourself.
+4. Raw material goes to `00 Inbox/`; each member works on a `member/<name>-<task>` branch.
+5. The lead/integrator reviews PRs, gathers them into `integrate/<scope>-YYYY-MM-DD`, and merges to `main`.
 
-## 구조
-
-```text
-000 HOME.md          # 사람이든 AI든 시작하는 대시보드
-AGENTS.md            # AI/사람 공통 작업 규칙 + 킥오프 시작 게이트
-CLAUDE.md            # Claude Code용 진입점 (AGENTS.md를 임포트)
-ONBOARDING.md        # 첫 이틀 온보딩 절차 (저장소 준비→킥오프→팀원 합류→첫 회의)
-TEAM-GUIDE.md        # Git을 몰라도 따라 할 팀원 안내
-_system/             # 현재 상태·결정·팀·용어·규칙 — 공식 기준점
-00 Inbox/            # 아직 정리하지 않은 원본과 접수 대장
-00 Project Hub/      # 저장소 전체 지도
-01 Meetings/         # 회의록
-02 Decisions/        # 확정된 ADR/결정
-03 Research/         # 조사와 PDF/PPT/Word의 Markdown 정리본
-04 Worklogs/         # 개인 작업 기록
-05 Tasks/            # 공식 할 일
-06 Team/             # 팀원별 담당과 AI 프롬프트
-07 Outputs/          # 기획서·데모·발표 등 산출물
-90 Archive/          # 종료된 작업
-99 Templates/        # 회의록·결정·리서치 양식
-```
-
-## AI에게 이렇게 요청하세요
+## Structure
 
 ```text
-이 저장소를 읽고 현재 프로젝트 맥락을 파악해줘.
-읽는 순서는 000 HOME.md → AGENTS.md → _system/CURRENT_STATE.md →
-_system/DECISION_LOG.md → 요청과 직접 관련 있는 근거 문서야.
-
-새 자료는 원본을 보관한 채 Markdown으로 정리하고,
-확정된 내용은 결정 로그와 현재 상태에 반영할 항목을 제안해줘.
-결정되지 않은 내용은 추측하지 말고 질문으로 남겨줘.
+000 HOME.md          # The dashboard everyone — human or AI — starts from
+AGENTS.md            # Shared rules for AI and humans + kickoff start gate
+CLAUDE.md            # Entry point for Claude Code (imports AGENTS.md)
+ONBOARDING.md        # First-two-days flow (repo setup → kickoff → joining → first meeting)
+TEAM-GUIDE.md        # A guide teammates can follow without knowing Git
+_system/             # Current state, decisions, team, glossary, rules — the official baseline
+00 Inbox/            # Unsorted raw material and the intake ledger
+00 Project Hub/      # Map of the whole repository
+01 Meetings/         # Meeting notes
+02 Decisions/        # Confirmed ADRs/decisions
+03 Research/         # Research and Markdown digests of PDF/PPT/Word files
+04 Worklogs/         # Personal work logs
+05 Tasks/            # Official to-dos
+06 Team/             # Per-member responsibilities and AI prompts
+07 Outputs/          # Deliverables: plans, demos, presentations
+90 Archive/          # Closed work
+99 Templates/        # Forms for meetings, decisions, research
 ```
 
-## 원본과 Markdown을 함께 보관하기
+## Ask your AI like this
 
-PDF·PPT·Word·회의 녹음은 해당 폴더의 `_raw/`에 원본으로 보관합니다. MarkItDown 같은 도구로 추출·정리한 `.md`는 같은 폴더 바로 아래에 둡니다. 정리본 첫 줄에는 원본 경로를 적습니다.
+```text
+Read this repository and pick up the current project context.
+Reading order: 000 HOME.md → AGENTS.md → _system/CURRENT_STATE.md →
+_system/DECISION_LOG.md → the evidence documents relevant to my request.
+
+For new material, keep the original and digest it into Markdown.
+For anything confirmed, propose updates to the decision log and current state.
+For anything undecided, don't guess — leave it as a question.
+```
+
+## Keep originals alongside Markdown
+
+Store PDF/PPT/Word files and meeting recordings as originals in the folder's `_raw/`. Put the `.md` extracted with tools like MarkItDown right next to it in the same folder. The first line of a digest names its origin:
 
 ```md
-> 원본: _raw/interview-notes.pdf
+> Origin: _raw/interview-notes.pdf
 ```
 
-## 중요한 한계
+## An important limitation
 
-이 템플릿의 문서는 운영 기준입니다. `main` 보호와 required review는 GitHub 저장소 Settings에서 별도로 켜야 실제 권한 제어가 됩니다.
+The documents in this template are an operating baseline. `main` branch protection and required reviews must be enabled separately in the repository Settings on GitHub to become real access control.
 
 ## License
 

--- a/TEAM-GUIDE.md
+++ b/TEAM-GUIDE.md
@@ -1,21 +1,21 @@
-# TEAM GUIDE — Git을 몰라도 쓰는 법
+# TEAM GUIDE — Using this without knowing Git
 
-> 팀에 처음 합류했나요? `ONBOARDING.md`의 **2단계 — 팀원 합류** 순서대로 하면 됩니다. 이 문서는 그 뒤에도 계속 쓰는 일상 사용법입니다.
+> Just joined? Follow **step 2 — Members join** in `ONBOARDING.md`. This document is the everyday manual you keep using afterwards.
 
-## 자료를 넣을 때
-- 링크·사진·PDF·PPT·회의 전사처럼 아직 정리 안 된 것은 `00 Inbox/`에 넣습니다.
-- AI에게 “이 자료 원본은 보관하고 Markdown으로 정리해줘”라고 요청합니다.
+## Adding material
+- Anything unsorted — links, photos, PDFs, PPTs, meeting transcripts — goes into `00 Inbox/`.
+- Ask the AI: "Keep the original and digest this into Markdown."
 
-## 내 작업을 올릴 때
-1. `member/<이름>-<작업>` 브랜치를 만듭니다.
-2. 회의록은 `01 Meetings/`, 리서치는 `03 Research/`, 개인 메모는 `04 Worklogs/`, 결과물은 `07 Outputs/`에 둡니다.
-3. 커밋 메시지에 무엇을 했고 원본이 어디인지 적습니다.
-4. PR을 열어 통합 책임자에게 검토를 요청합니다.
+## Publishing your work
+1. Create a `member/<name>-<task>` branch.
+2. Meeting notes go to `01 Meetings/`, research to `03 Research/`, personal notes to `04 Worklogs/`, deliverables to `07 Outputs/`.
+3. Write commit messages that say what you did and where the original lives.
+4. Open a PR and request review from the integrator.
 
-## 직접 고치면 안 되는 파일
-`000 HOME.md`, `AGENTS.md`, `TEAM-GUIDE.md`, `_system/`, `02 Decisions/`, `05 Tasks/`는 팀의 공식 기준입니다. 변경이 필요하면 PR에 이유를 적고 통합 요청을 합니다.
+## Files you must not edit directly
+`000 HOME.md`, `AGENTS.md`, `CLAUDE.md`, `ONBOARDING.md`, `TEAM-GUIDE.md`, `_system/`, `02 Decisions/`, `05 Tasks/` are the team's official baseline. If a change is needed, explain why in a PR and request integration.
 
-## AI에게 물어볼 수 있는 것
-- “지금까지 무엇을 했어?” → `CURRENT_STATE`, 최근 회의록, 작업 로그를 근거로 답합니다.
-- “왜 이 방향으로 갔어?” → 결정 로그와 ADR을 근거로 답합니다.
-- “Claude Design으로 이 프로토타입을 만들 프롬프트를 써줘.” → 현재 상태와 결정을 먼저 읽게 합니다.
+## What you can ask the AI
+- "What has been done so far?" → answers from `CURRENT_STATE`, recent meeting notes, and worklogs.
+- "Why did we go this direction?" → answers from the decision log and ADRs.
+- "Write a Claude Design prompt for this prototype." → it reads current state and decisions first.

--- a/_system/BRANCH_LIFECYCLE.md
+++ b/_system/BRANCH_LIFECYCLE.md
@@ -1,35 +1,35 @@
-# BRANCH_LIFECYCLE — 브랜치가 쌓이지 않게 하는 규칙
+# BRANCH_LIFECYCLE — Keeping branches from piling up
 
-## 목적
+## Purpose
 
-작업 브랜치는 무기한 방치하지 않는다. 그러나 고유 커밋이 있는 브랜치를 자동 삭제하거나 강제로 main에 맞추지도 않는다. 먼저 **감사 → 담당자 확인 → 선별 반영/보관 → 정리** 순서로 처리한다.
+Work branches are not left unattended forever. But branches with unique commits are never auto-deleted or force-reset to main either. The order is always **audit → confirm with the owner → selectively integrate/archive → clean up**.
 
-## 상태
+## States
 
-| 상태 | 기준 | 다음 행동 |
+| State | Criteria | Next action |
 |---|---|---|
-| active | 작업 중 또는 열린 PR | 담당자가 계속 작업/PR 갱신 |
-| review | `main`보다 앞선 고유 커밋이 있으나 PR 없음 | 7일 안에 담당자가 PR·보관·폐기 중 선택 |
-| stale | 14일 이상 갱신 없고 main보다 뒤처짐 | 자동 감사가 보고, 담당자에게 확인 |
-| cleanable | `main`보다 ahead 0 | 외부 참조 확인 후 삭제 후보 |
-| archived | 검토 결과 보존만 필요 | `archive/<원래 브랜치>` 태그 후 브랜치 삭제 가능 |
+| active | being worked on, or has an open PR | owner keeps working / updates the PR |
+| review | unique commits ahead of `main`, but no PR | within 7 days the owner picks: PR, archive, or drop |
+| stale | no updates for 14+ days and behind main | the automated audit reports it; confirm with the owner |
+| cleanable | 0 ahead of `main` | deletion candidate after checking external references |
+| archived | review concluded keep-only | tag `archive/<original branch>`, then the branch may be deleted |
 
-## 개인 브랜치 재사용
+## Reusing a personal branch
 
-같은 작업 브랜치(`member/<이름>-<작업>`)를 다음 작업에도 계속 쓰고 싶다면 PR이 main에 머지된 뒤에만 아래를 실행합니다.
+If you want to keep using the same work branch (`member/<name>-<task>`) for the next task, run this only after your PR has merged to main:
 
 ```bash
 git fetch origin
-git switch member/<이름>-<작업>
-git status --short  # 반드시 비어 있어야 함
+git switch member/<name>-<task>
+git status --short  # must be empty
 git reset --hard origin/main
-git push --force-with-lease origin member/<이름>-<작업>
+git push --force-with-lease origin member/<name>-<task>
 ```
 
-- 이름은 유지하고 내용만 main과 같게 만듭니다.
-- 아직 PR에 넣지 않은 작업이 있으면 실행하지 않습니다.
-- 다른 사람의 브랜치에는 force-push하지 않습니다.
+- The name stays; only the content is aligned with main.
+- Never run this while you have work not yet in a PR.
+- Never force-push someone else's branch.
 
-## 자동화 범위
+## Scope of automation
 
-`.github/workflows/branch-audit.yml`은 매주 **읽기 전용 감사 보고서**를 만듭니다. 브랜치별 ahead/behind와 마지막 커밋 경과일을 계산해 위 표의 stale(14일) 후보까지 표시하고, 결과를 저장소의 "Branch audit report" 이슈에 올립니다. 자동 삭제·자동 reset은 하지 않습니다. 고유 작업을 지우는 자동화는 위험하며, 담당자와 팀장의 명시적 결정이 필요합니다.
+`.github/workflows/branch-audit.yml` produces a weekly **read-only audit report**. It computes each branch's ahead/behind and days since its last commit, flags stale (14-day) candidates from the table above, and posts the result to the repository's "Branch audit report" issue. It never auto-deletes or auto-resets. Automation that destroys unique work is dangerous and requires an explicit decision by the owner and the lead.

--- a/_system/CURRENT_STATE.md
+++ b/_system/CURRENT_STATE.md
@@ -1,21 +1,21 @@
-# CURRENT_STATE — 현재 상태
+# CURRENT_STATE — Where things stand
 
-> 통합 책임자만, 근거가 확인된 내용으로 갱신합니다. 한 화면 안에 유지합니다.
+> Only the integrator updates this, with verified content. Keep it within one screen.
 
-## 목표
-- **프로젝트:** [이름]
-- **한 줄 정의:** [누구의 어떤 문제를 어떻게 푸는가]
+## Goal
+- **Project:** [name]
+- **One-line definition:** [whose problem, solved how]
 
-## 현재 단계
-- [지금 어디까지 왔는가]
+## Current phase
+- [how far we've come]
 
-## 다음 할 일 (Top 3)
-1. [가장 중요한 다음 행동]
-2. [두 번째 행동]
-3. [세 번째 행동]
+## Next tasks (top 3)
+1. [most important next action]
+2. [second action]
+3. [third action]
 
-## 미해결 / 질문
-- [결정이 필요한 항목]
+## Open / questions
+- [items that need a decision]
 
-## 최근 확정
-- [날짜] [결정 요약] → `02 Decisions/ADR-0001-...md`
+## Recently confirmed
+- [date] [decision summary] → `02 Decisions/ADR-0001-...md`

--- a/_system/DECISION_LOG.md
+++ b/_system/DECISION_LOG.md
@@ -1,7 +1,7 @@
-# DECISION_LOG — 확정된 결정
+# DECISION_LOG — Confirmed decisions
 
-> 논의 중인 내용은 회의록·작업 브랜치에 남기고, 확정된 것만 통합 책임자가 여기에 기록합니다.
+> Ongoing discussion stays in meeting notes and work branches; only confirmed decisions land here, written by the integrator.
 
-| 날짜 | 결정 | 이유 | 근거/상세 |
+| Date | Decision | Why | Evidence/details |
 |---|---|---|---|
-| YYYY-MM-DD | [결정] | [왜] | `02 Decisions/ADR-0001-...md` |
+| YYYY-MM-DD | [decision] | [reason] | `02 Decisions/ADR-0001-...md` |

--- a/_system/GLOSSARY.md
+++ b/_system/GLOSSARY.md
@@ -1,12 +1,12 @@
-# GLOSSARY — 공통 용어
+# GLOSSARY — Shared terms
 
-> 제품·데이터·업무 용어를 같은 뜻으로 사용하기 위한 기준입니다. 새 용어가 팀의 판단이나 구현에 영향을 주면 여기에 먼저 정의합니다.
+> The baseline for using product, data, and domain terms to mean the same thing. If a new term affects the team's judgment or implementation, define it here first.
 
-| 용어 | 정의 | 참고 |
+| Term | Definition | Reference |
 |---|---|---|
-| [용어] | [팀이 합의한 뜻] | [관련 결정/문서 링크] |
+| [term] | [the meaning the team agreed on] | [related decision/document link] |
 
-## 작성 규칙
-- 일상어라도 프로젝트 안에서 다른 뜻으로 쓰이면 기록합니다.
-- 정의를 바꾸면 `DECISION_LOG.md`에 이유와 날짜를 남깁니다.
-- 외부 약어·지표는 원문 출처 또는 계산식을 함께 적습니다.
+## Rules
+- Record even everyday words if the project uses them with a different meaning.
+- When a definition changes, log the reason and date in `DECISION_LOG.md`.
+- For external acronyms and metrics, include the original source or the formula.

--- a/_system/INTEGRATION_RULES.md
+++ b/_system/INTEGRATION_RULES.md
@@ -1,19 +1,19 @@
-# INTEGRATION_RULES — 브랜치와 PR
+# INTEGRATION_RULES — Branches and PRs
 
-| 구분 | 이름 | 할 수 있는 일 | 할 수 없는 일 |
+| Kind | Name | Can do | Cannot do |
 |---|---|---|---|
-| 팀원 작업 브랜치 | `member/<이름>-<작업>` | 원본·회의록·리서치·작업로그·산출물 | 공식 상태/결정/우선순위 변경 |
-| 통합 브랜치 | `integrate/<범위>-YYYY-MM-DD` | 여러 PR 통합, 보호 파일 갱신, 충돌 해소 | 팀장 승인 없이 main 머지 |
-| `main` | 공식 기준선 | 검토 완료 PR 반영 | 직접 작업/직접 push |
+| Member work branch | `member/<name>-<task>` | originals, meeting notes, research, worklogs, outputs | change official state/decisions/priorities |
+| Integration branch | `integrate/<scope>-YYYY-MM-DD` | combine PRs, update protected files, resolve conflicts | merge to main without lead approval |
+| `main` | official baseline | receive reviewed PRs | direct work / direct pushes |
 
-## 보호 파일
-`000 HOME.md`, `AGENTS.md`, `TEAM-GUIDE.md`, `_system/**`, `02 Decisions/**`, `05 Tasks/**`, `.github/**`는 통합 책임자만 변경합니다.
+## Protected files
+`000 HOME.md`, `AGENTS.md`, `CLAUDE.md`, `ONBOARDING.md`, `TEAM-GUIDE.md`, `_system/**`, `02 Decisions/**`, `05 Tasks/**`, `.github/**` are changed only by the integrator.
 
-## 절차
-1. 팀원은 작업 브랜치에서 근거와 초안을 커밋합니다.
-2. PR에 범위·출처·기존 결정과의 충돌 여부를 적습니다.
-3. 통합 책임자가 검토하고 필요하면 질문합니다.
-4. `integrate/...`에서 `CURRENT_STATE`, `DECISION_LOG`, ADR, 공식 태스크를 함께 갱신합니다.
-5. 팀장이 최종 PR을 승인해 `main`에 반영합니다.
+## Procedure
+1. Members commit evidence and drafts on their work branches.
+2. The PR states its scope, sources, and whether it conflicts with existing decisions.
+3. The integrator reviews and asks questions where needed.
+4. On `integrate/...`, update `CURRENT_STATE`, `DECISION_LOG`, ADRs, and official tasks together.
+5. The lead approves the final PR into `main`.
 
-> GitHub Settings에서 main branch protection과 required reviews를 켜야 실제 권한 제어가 됩니다.
+> Enable main branch protection and required reviews in GitHub Settings to make this real access control.

--- a/_system/KICKOFF_INTERVIEW.md
+++ b/_system/KICKOFF_INTERVIEW.md
@@ -1,73 +1,75 @@
-# KICKOFF_INTERVIEW — 프로젝트 시작 인터뷰
+# KICKOFF_INTERVIEW — Project start interview
 
-상태: 대기
+Status: pending
+Language: not set
 
-> 위 `상태:`가 `대기`인 동안, AI는 어떤 작업보다 먼저 이 인터뷰를 팀장에게 제안합니다 (`AGENTS.md`의 시작 게이트).
-> 인터뷰가 끝나면 AI가 첫 줄을 `상태: 완료 (YYYY-MM-DD)`로 바꿉니다. 다시 하려면 `대기`로 되돌립니다.
+> While `Status:` above is `pending`, the AI proposes this interview to the team lead before any other work (see the start gate in `AGENTS.md`).
+> When the interview ends, the AI changes the first line to `Status: done (YYYY-MM-DD)`. Reset it to `pending` to run it again.
 
-## 목적
+## Purpose
 
-새 팀이 이 템플릿을 쓰기 시작할 때, AI가 팀장을 인터뷰해서 팀 구성·연락처·특기·팀 규범·목표를 받아 공식 문서를 대신 채웁니다. 팀장은 대괄호 파일을 직접 편집할 필요가 없습니다.
+When a new team adopts this template, the AI interviews the team lead for team makeup, contacts, strengths, team norms, and goals, then fills the official documents. The lead never has to edit placeholder files by hand.
 
-## AI 진행 규칙
+## Rules for the AI
 
-1. 아래 5개 묶음을 **한 묶음씩** 묻습니다. 한 번에 전부 묻지 않습니다.
-2. **(필수)** 표시 항목은 반드시 받습니다. 나머지는 "건너뛰기"를 허용하고, 건너뛴 항목은 `_system/CURRENT_STATE.md`의 미해결/질문에 남깁니다.
-3. **민감 정보 규칙**: 인터뷰 시작 때 저장소 공개 여부부터 확인합니다 (`gh repo view --json visibility` 또는 팀장에게 질문). 팀 저장소는 **프라이빗이 기본**입니다 — 공개(public)로 확인되면 비공개 전환(Settings → General → Danger Zone → Change visibility)을 먼저 권합니다. 그래도 공개를 유지한다면 전화번호·개인 이메일을 커밋되는 어떤 파일에도 쓰지 않고 `_system/TEAM_CONTACTS.local.md`(gitignore됨, 팀장 로컬에만 존재)에만 기록합니다. 비공개(private)라면 팀장 선택에 따라 `_system/TEAM.md`에 적을 수 있습니다.
-4. 답을 지어내지 않습니다. 모호하면 되묻고, 결정되지 않은 것은 미해결로 남깁니다.
-5. 인터뷰가 끝나면 아래 **기록 위치**대로 문서를 갱신하고, 바꾼 파일 목록을 팀장에게 보여준 뒤 커밋을 제안합니다.
-6. 마지막으로 이 파일의 `상태:`를 갱신합니다.
-7. 이 인터뷰는 `ONBOARDING.md`의 1단계입니다. 완료하면 팀장에게 다음 단계 — 팀원 초대(0단계를 건너뛰었다면)와 팀원 온보딩 PR(2단계) — 를 안내합니다.
+1. **Ask the working language first.** Before anything else, ask which language the team works in (e.g., English, Korean). Record it in the `Language:` line above, then conduct the interview — and write all generated notes — in that language. File names, folder structure, and the `Status:` keywords stay in English.
+2. Ask the five groups below **one group at a time**. Never all at once.
+3. Items marked **(required)** must be answered. Everything else can be skipped; skipped items go to the open questions in `_system/CURRENT_STATE.md`.
+4. **Sensitive data rule**: check repository visibility at the start (`gh repo view --json visibility` or ask the lead). Team repositories default to **private** — if the repo turns out to be public, first recommend switching it to private (Settings → General → Danger Zone → Change visibility). If it stays public anyway, never write phone numbers or personal emails into any committed file; record them only in `_system/TEAM_CONTACTS.local.md` (gitignored, exists only on the lead's machine). If private, the lead may choose to keep them in `_system/TEAM.md`.
+5. Never invent answers. If something is ambiguous, ask again; if undecided, leave it open.
+6. When the interview ends, update the documents per **Where answers go**, show the lead the list of changed files, and offer to commit.
+7. Finally, update the `Status:` line of this file.
+8. This interview is step 1 of `ONBOARDING.md`. On completion, point the lead to the next steps — inviting members (if step 0 was skipped) and member onboarding PRs (step 2).
 
-## 질문 묶음
+## Question groups
 
-### 1) 프로젝트와 목표 (필수)
-- 프로젝트 이름과 한 줄 정의 — 누구의 어떤 문제를 푸는가
-- 이 프로젝트로 이루고 싶은 것 — 팀 공동 목표 (예: 수상, 학점, 포트폴리오, 실사용자)
-- 성공의 정의 — 마감일에 무엇이 있으면 성공했다고 볼 것인가
-- 최종 마감일과 중간 마일스톤 (발표일·제출일 등)
+### 1) Project and goals (required)
+- Project name and one-line definition — whose problem does it solve
+- What the team wants out of this project — the shared goal (e.g., award, grade, portfolio, real users)
+- Definition of success — what must exist on deadline day to call it a success
+- Final deadline and intermediate milestones (presentation and submission dates)
 
-### 2) 팀 구성 (필수: 인원수와 각자의 이름/별칭)
-- 팀 인원수, 각 팀원의 이름 또는 별칭
-- 팀장과 통합 책임자는 누구인가
-- 저장소는 공개인가 비공개인가 (민감 정보 저장 위치가 달라짐)
+### 2) Team makeup (required: headcount and each member's name/alias)
+- Number of members, each member's name or alias
+- Who is the lead, who is the integrator
+- Is the repository private or public (this changes where sensitive data goes)
 
-### 3) 연락처 (팀원별)
-- GitHub ID (협업에 필요 — 권장)
-- 팀이 쓰는 채널의 주소/핸들: Discord, Slack, Gmail, Figma, 전화번호(민감) 등
-- 주 연락 채널 하나와, 급할 때 쓰는 채널
-- 메시지 응답 기대 시간 (예: 24시간 안)
+### 3) Contacts (per member)
+- GitHub ID (needed for collaboration — recommended)
+- Handles for whatever the team uses: Discord, Slack, Gmail, Figma, phone (sensitive), etc.
+- One primary channel, plus the channel for urgent matters
+- Expected response time (e.g., within 24 hours)
 
-### 4) 특기·역할·가용 시간 (팀원별)
-- 잘하는 것/장점 (예: 발표, 디자인, 데이터 분석, 글쓰기, 코드)
-- 맡고 싶은 역할과 이 프로젝트에서 배우고 싶은 것
-- 주당 투입 가능 시간과 안 되는 시간대 (시험 기간 등 일정 리스크 포함)
-- Git/GitHub 익숙한 정도 (`TEAM-GUIDE.md` 안내가 필요한 사람 파악)
+### 4) Strengths, roles, availability (per member)
+- What they're good at (e.g., presenting, design, data analysis, writing, code)
+- The role they want, and what they want to learn from this project
+- Weekly hours available and hard-blocked time slots (including schedule risks like exam periods)
+- Git/GitHub familiarity (identifies who needs `TEAM-GUIDE.md`)
 
-### 5) 팀 규범 — 지켜줬으면 하는 점
-- 회의: 주기, 요일/시간대, 지각·불참 규칙
-- 마감을 못 지킬 것 같을 때 언제까지 누구에게 알리는가
-- 의사결정 방식 (합의 / 다수결 / 팀장 결정)과 동률일 때 타이브레이커
-- 갈등·무임승차가 생겼을 때 처리 원칙
-- 그 외 서로 부탁하고 싶은 것 (자유)
+### 5) Team norms — what we ask of each other
+- Meetings: cadence, day/time, rules for lateness and absence
+- When someone can't make a deadline: by when, and whom, must they tell
+- Decision-making style (consensus / majority / lead decides) and the tie-breaker
+- How conflict or free-riding is handled
+- Anything else members want from each other (open)
 
-## 기록 위치
+## Where answers go
 
-| 받은 정보 | 기록할 파일 |
+| Collected | Written to |
 |---|---|
-| 프로젝트 이름·한 줄 정의·현재 단계 | `000 HOME.md`, `_system/CURRENT_STATE.md` |
-| 목표·성공 정의·마일스톤 | `000 HOME.md`, `_system/CURRENT_STATE.md` (마일스톤은 다음 할 일로) |
-| 팀원·역할·통합 권한·공개 가능한 핸들 | `_system/TEAM.md` |
-| 팀원별 특기·가용 시간·개인 목표 | `06 Team/<별칭>.md` (`99 Templates/member.md` 양식 사용) |
-| 팀 규범 | `_system/WORKING_AGREEMENTS.md` |
-| 전화번호·개인 이메일 등 민감 연락처 | `_system/TEAM_CONTACTS.local.md` — **커밋 금지**, 팀장 로컬 보관 |
+| Project name, one-line definition, phase | `000 HOME.md`, `_system/CURRENT_STATE.md` |
+| Goals, definition of success, milestones | `000 HOME.md`, `_system/CURRENT_STATE.md` (milestones as next tasks) |
+| Members, roles, integration rights, public handles | `_system/TEAM.md` |
+| Per-member strengths, availability, personal goals | `06 Team/<alias>.md` (use `99 Templates/member.md`) |
+| Team norms | `_system/WORKING_AGREEMENTS.md` |
+| Sensitive contacts (phone, personal email) | `_system/TEAM_CONTACTS.local.md` — **never committed**, lead's machine only |
 
-## TEAM_CONTACTS.local.md 양식 (gitignore됨 — 커밋되지 않음)
+## TEAM_CONTACTS.local.md format (gitignored — never committed)
 
 ```md
-# TEAM_CONTACTS (local only — git에 올리지 않음)
+# TEAM_CONTACTS (local only — never pushed to git)
 
-| 이름 | 전화 | 이메일 | 비고 |
+| Name | Phone | Email | Notes |
 |---|---|---|---|
-| [이름] | [번호] | [주소] | - |
+| [name] | [number] | [address] | - |
 ```

--- a/_system/PROJECT_RULES.md
+++ b/_system/PROJECT_RULES.md
@@ -1,8 +1,8 @@
-# PROJECT_RULES — 파일·기록 규칙
+# PROJECT_RULES — Files and records
 
-- 날짜 파일명: `YYYY-MM-DD-주제.md`
-- 회의록에는 참석자, 논의, 결정 후보, 다음 행동을 적습니다.
-- 확정 결정은 `02 Decisions/ADR-NNNN-제목.md`로 분리합니다.
-- 원본 파일은 `_raw/`, Markdown 정리본은 같은 폴더 바로 아래에 둡니다.
-- Markdown 정리본 첫 줄: `> 원본: _raw/파일명.pdf`
-- 커밋: `docs: 회의록 정리`, `research: 시장 조사 자료 추가`, `output: 발표 슬라이드 초안`처럼 범위와 내용을 씁니다.
+- Dated file names: `YYYY-MM-DD-topic.md`
+- Meeting notes include attendees, discussion, decision candidates, and next actions.
+- Confirmed decisions split out into `02 Decisions/ADR-NNNN-title.md`.
+- Original files live in `_raw/`; the Markdown digest sits right next to them in the same folder.
+- First line of a digest: `> Origin: _raw/filename.pdf`
+- Commits state scope and content: `docs: digest meeting notes`, `research: add market survey material`, `output: draft slide deck`.

--- a/_system/TEAM.md
+++ b/_system/TEAM.md
@@ -1,19 +1,19 @@
-# TEAM — 역할과 연락 기준
+# TEAM — Roles and how to reach people
 
-> 공개 저장소에는 실명·전화번호·개인 연락처를 넣지 않습니다.
+> Public repositories get no real names, phone numbers, or personal contact details.
 
-| 역할 | GitHub ID/별칭 | 담당 | 통합 권한 |
+| Role | GitHub ID/alias | Owns | Integration rights |
 |---|---|---|---|
-| 팀장 | [id] | 최종 승인 | main 승인 |
-| 통합 책임자 | [id] | PR 검토·공식 상태/결정 갱신 | integrate/main PR |
-| 팀원 | [id] | 자료·리서치·산출물 | 작업 브랜치 |
+| Lead | [id] | final approval | approves `main` |
+| Integrator | [id] | PR review, official state/decision updates | integrate/main PRs |
+| Member | [id] | material, research, outputs | work branches |
 
-## 연락 핸들 (공개해도 되는 범위만)
+## Contact handles (public-safe only)
 
-| 별칭 | GitHub | Discord | Slack | Figma | 주 채널 / 응답 기대 |
+| Alias | GitHub | Discord | Slack | Figma | Primary channel / response time |
 |---|---|---|---|---|---|
-| [별칭] | [id] | - | - | - | [채널 / 24시간 안] |
+| [alias] | [id] | - | - | - | [channel / within 24h] |
 
-- 전화번호·개인 이메일은 공개 저장소에 커밋하지 않습니다. 팀장이 `_system/TEAM_CONTACTS.local.md`(gitignore됨)에 보관합니다. 비공개 저장소라면 팀 합의로 이 표에 컬럼을 추가할 수 있습니다.
-- 팀원별 특기·가용 시간·개인 목표는 `06 Team/<별칭>.md`에 있습니다.
-- 이 파일은 킥오프 인터뷰(`_system/KICKOFF_INTERVIEW.md`)가 채웁니다.
+- Phone numbers and personal emails are never committed to a public repository. The lead keeps them in `_system/TEAM_CONTACTS.local.md` (gitignored). In a private repository, the team may agree to add columns here instead.
+- Per-member strengths, availability, and personal goals live in `06 Team/<alias>.md`.
+- This file is filled by the kickoff interview (`_system/KICKOFF_INTERVIEW.md`).

--- a/_system/UPLOAD_RULES.md
+++ b/_system/UPLOAD_RULES.md
@@ -1,7 +1,7 @@
-# UPLOAD_RULES — 원본 보관과 Markdown 변환
+# UPLOAD_RULES — Originals and Markdown conversion
 
-1. PDF·PPT·Word·녹음 원본은 버리지 않고 해당 폴더의 `_raw/`에 둡니다.
-2. MarkItDown 등으로 텍스트를 추출·정리한 Markdown은 같은 폴더 바로 아래에 둡니다.
-3. 정리본 첫 줄에 원본 경로를 둡니다.
-4. 큰 발표 자료·영상은 Git LFS 또는 Drive 링크를 사용합니다. GitHub 일반 Git은 파일당 100MB를 넘길 수 없습니다.
-5. AI는 원본을 덮어쓰지 않고, 정리본에서 사실/해석/미확인을 구분합니다.
+1. Never discard PDF/PPT/Word/recording originals; keep them in the folder's `_raw/`.
+2. Markdown extracted and cleaned with tools like MarkItDown goes right next to them in the same folder.
+3. The first line of a digest names the original's path.
+4. For large decks and video, use Git LFS or a Drive link. Plain Git on GitHub cannot exceed 100 MB per file.
+5. AI never overwrites originals, and separates fact / interpretation / unverified in digests.

--- a/_system/WORKING_AGREEMENTS.md
+++ b/_system/WORKING_AGREEMENTS.md
@@ -1,22 +1,22 @@
-# WORKING_AGREEMENTS — 팀 규범
+# WORKING_AGREEMENTS — Team norms
 
-> 킥오프 인터뷰에서 합의한 팀의 약속입니다. 바꾸면 `DECISION_LOG.md`에 날짜와 이유를 남깁니다.
+> The commitments agreed in the kickoff interview. Changes get a date and reason in `DECISION_LOG.md`.
 
-## 회의
-- 주기/시간대: [예: 매주 화 21:00, 30분]
-- 지각·불참: [예: 2시간 전까지 팀 채널에 공유]
+## Meetings
+- Cadence/time: [e.g., every Tue 21:00, 30 min]
+- Lateness/absence: [e.g., post in the team channel at least 2 hours ahead]
 
-## 커뮤니케이션
-- 주 채널: [예: Discord] / 급할 때: [예: 전화]
-- 응답 기대 시간: [예: 24시간 안]
-- 마감을 못 지킬 것 같으면: [예: 마감 48시간 전까지 팀장에게 먼저 알림]
+## Communication
+- Primary channel: [e.g., Discord] / urgent: [e.g., phone]
+- Expected response time: [e.g., within 24 hours]
+- If a deadline looks at risk: [e.g., tell the lead at least 48 hours before]
 
-## 의사결정
-- 방식: [합의 / 다수결 / 팀장 결정]
-- 동률·교착일 때: [예: 팀장이 결정하고 `DECISION_LOG.md`에 기록]
+## Decision-making
+- Style: [consensus / majority / lead decides]
+- On ties or deadlock: [e.g., the lead decides and logs it in `DECISION_LOG.md`]
 
-## 갈등·무임승차
-- [예: 1차는 당사자 간 대화, 2차는 회의 안건으로, 논의는 회의록에 기록]
+## Conflict and free-riding
+- [e.g., first a direct conversation, then a meeting agenda item; the discussion is recorded in meeting notes]
 
-## 서로 지켜줬으면 하는 점
-- [자유 항목 — 킥오프 인터뷰 5번 묶음의 답]
+## What we ask of each other
+- [open items — answers from question group 5 of the kickoff interview]


### PR DESCRIPTION
## What changed?

- **Full English localization** — every document in the vault is now English: root guides (README, AGENTS, ONBOARDING, TEAM-GUIDE, HOME), all of `_system/`, folder READMEs, templates, PR template, CODEOWNERS/.gitattributes/.gitignore comments. Zero Hangul characters remain (verified by grep).
- **Working-language selection at kickoff** — `_system/KICKOFF_INTERVIEW.md` now has a `Language:` field, and rule #1 makes the AI ask the team's working language before anything else, then conduct the interview and write all generated notes in that language. File names, structure, and `Status:` keywords stay English. `AGENTS.md` gets a matching "Working language" section.
- Status sentinel keywords normalized to `pending` / `done` across AGENTS.md, KICKOFF_INTERVIEW.md, and ONBOARDING.md.
- Protected-file lists in `INTEGRATION_RULES.md` and `TEAM-GUIDE.md` now include `CLAUDE.md` and `ONBOARDING.md` (matching CODEOWNERS).

## Evidence / originals

- Follow-up to #1; owner requested an English-only repository with language choice at onboarding.

## Does this conflict with an existing decision?
- [x] No

## Checklist
- [ ] Originals are stored in `_raw/`. — N/A (docs localization)
- [ ] The Markdown digest names its original's path. — N/A
- [ ] If filing from the Inbox, `00 Inbox/INTAKE_INDEX.md` status and final location are updated. — N/A
- [ ] No protected files changed. — **Protected files changed; this is an `integrate/` PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
