### PR TITLE
docs: fix bilingual navigation and governance modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ The template ships in English. The kickoff interview asks for the team's working
 4. Documents in the folders directly relevant to the request
 
 ## Context management — humans upload, AI organizes
-- **Humans only upload into `00 Inbox/`.** The numbered folders (01–07), `_system/`, and the folder structure are created and organized **by AI/automation under owner approval**. This keeps the context curated to one consistent standard.
+- **Humans only upload into `00 Inbox/`.** The numbered folders (01–07), `_system/`, and the folder structure are created and organized **by AI/automation under owner oversight**. This keeps the context curated to one consistent standard.
 - Non-owners never modify the base folder structure. The protected-file list lives in `_system/INTEGRATION_RULES.md`; who counts as an owner is defined in `_system/GOVERNANCE.md` (template placeholder: `{{OWNER_HANDLE}}`).
 - **AI confirms with the branch's human before pushing.** Especially after digesting new Inbox material: ask "I organized it — push?" and only then push.
-- Enforcement = `protected-paths` CI (which files are protected) + `guard-structure` CI (who may land on main) + branch protection. *"Was it AI or a human" cannot be told apart technically — enforcement works by path + approval + PR author instead.* Details: `_system/GOVERNANCE.md`.
+- The default is **single-writer mode**: `protected-paths` CI and `guard-structure` CI provide signals, not required merge gates. Before a fork or multi-writer transition, explicitly choose whether to enable branch protection, Code Owners review, and required checks. *"Was it AI or a human" cannot be told apart technically — enforcement works by path + authenticated PR author and, in team mode, approval instead.* Details: `_system/GOVERNANCE.md`.
 
 ## Inbox processing — all four steps, one commit
 An item counts as "organized" only when ALL of the following are done. If any is missing, it is not organized:

--- a/Project Hub/ONBOARDING.md
+++ b/Project Hub/ONBOARDING.md
@@ -19,7 +19,7 @@
    - GitHub's free plan allows unlimited collaborators on private repositories.
 2. In Settings → Collaborators, invite every member with **Write** access.
 3. Replace the `{{OWNER_HANDLE}}` placeholders with the integrator's GitHub handle in `.github/CODEOWNERS` and `.github/workflows/guard-structure.yml` (the kickoff interview offers to do this for you).
-4. Enable enforcement per `_system/GOVERNANCE.md`: on a public repo (or private + GitHub Pro), turn on `main` branch protection with Code Owners review and the required `guard` check. On a private repo with the free plan, branch protection returns 403 — the checks still run in **CI signal mode** (red ❌ on violations; merging isn't physically blocked).
+4. Choose a governance mode per `_system/GOVERNANCE.md`. The template starts in **single-writer mode** (CI signals, no required review/check gates). Before inviting multiple writers or forking for team use, decide whether to enable `main` branch protection, Code Owners review, and the required `guard` check. On a private repo with the free plan, unavailable protections leave the checks in **CI signal mode** (red ❌ on violations; merging is not physically blocked).
 5. Check the Actions tab to confirm workflows are enabled (weekly Branch audit + the two PR guards).
 
 ## Step 1 — Kickoff interview (lead + AI)

--- a/Project Hub/README.ko.md
+++ b/Project Hub/README.ko.md
@@ -1,91 +1,27 @@
-# Context Hippo 🦛
+# Project Hub — 저장소 지도
 
-<p align="center">
-  <img src="assets/context-hippo-hero.png" alt="입을 크게 벌린 검은 하마 — Context Hippo 마크" width="380" />
-</p>
+> `HOME.md`는 **지금 무엇을 할지** 알려주고, 이 문서는 **무엇이 어디에 있는지** 알려줍니다.
+> 이 폴더에는 사람을 위한 두 안내서도 있습니다: `ONBOARDING.md`(시작하기), `TEAM-GUIDE.md`(Git 지식 없이 일상적으로 쓰기).
+>
+> 기본 문서는 영어입니다. 전체 소개의 한국어판은 [루트 README.ko.md](../README.ko.md)에서 볼 수 있습니다.
 
-<p align="center"><a href="../README.md">English</a> · <b>한국어</b></p>
+| 찾는 것 | 위치 |
+|---|---|
+| 현재 목표·막힌 일·다음 행동 | `_system/CURRENT_STATE.md` |
+| 확정된 선택과 이유 | `_system/DECISION_LOG.md`, `02 Decisions/` |
+| 팀 구성과 담당 | `_system/TEAM.md`, `06 Team/` |
+| 팀 규범(회의·소통·결정) | `_system/WORKING_AGREEMENTS.md` |
+| 누가 무엇을 바꾸는지 / 운영 방식 | `_system/GOVERNANCE.md` |
+| 시작 온보딩·킥오프 | `Project Hub/ONBOARDING.md`, `_system/KICKOFF_INTERVIEW.md` |
+| Git 없이 쓰는 팀원 안내 | `Project Hub/TEAM-GUIDE.md` |
+| 미분류 자료 | `00 Inbox/`, `00 Inbox/INTAKE_INDEX.md` |
+| 회의 근거 | `01 Meetings/` |
+| 리서치와 원본 | `03 Research/` 및 각 폴더의 `_raw/` |
+| 개인 작업 기록 | `04 Worklogs/` |
+| 공식 할 일 | `05 Tasks/` |
+| 산출물 | `07 Outputs/` |
 
-팀의 흩어진 대화·회의·링크·문서를 받아, 사람과 AI가 함께 읽을 수 있는 **공유 맥락으로 소화하는** Obsidian + GitHub 템플릿입니다.
-
-Context Hippo는 자동으로 모든 자료를 처리하는 서비스가 아닙니다. 대신 원본을 어디에 넣고, 무엇을 Markdown으로 정리하며, 어떤 내용을 공식 결정과 현재 상태로 남길지 정합니다. 사람과 AI는 그 규칙을 함께 읽고 같은 프로젝트 맥락에서 작업합니다.
-
-> 이 문서는 한국어 안내판입니다. 저장소의 기준 문서는 영어(`README.md` 및 각 폴더 문서)이며, 내용이 다르면 영어판이 우선합니다. 킥오프 인터뷰에서 작업 언어로 한국어를 선택하면 AI가 만드는 노트·요약은 모두 한국어로 작성됩니다.
-
-## 작동 방식
-
-### 1. Capture — 원본을 모읍니다
-회의 전사, 링크, PDF·PPT·Word, 사진, 메모처럼 아직 정리되지 않은 것은 `00 Inbox/`에 넣습니다. 원본은 각 작업 폴더의 `_raw/`에 보관합니다.
-
-### 2. Digest — 읽을 수 있는 Markdown으로 소화합니다
-사람 또는 AI가 원본을 Markdown 노트로 정리하고, 내용의 성격에 따라 회의·리서치·작업 로그·산출물 폴더로 옮깁니다. 정리본은 항상 원본 위치를 가리킵니다.
-
-### 3. Decide — 공식 맥락을 갱신합니다
-확정된 선택은 `02 Decisions/`와 `_system/DECISION_LOG.md`에, 지금 진행 중인 일과 막힌 일은 `_system/CURRENT_STATE.md`에 남깁니다. 이 파일들이 팀의 공식 기준점입니다.
-
-### 4. Reuse — 다음 사람과 AI가 바로 이어받습니다
-새 팀원과 AI는 `Project Hub/HOME.md`부터 읽습니다. 볼트 전체를 훑지 않고도 현재 목표·결정·규칙·다음 행동을 파악한 뒤, 필요한 근거만 더 읽을 수 있습니다.
-
-## 시작하기
-
-1. 이 저장소를 **Use this template**으로 복제하되, 팀 저장소는 **반드시 Private**으로 만듭니다. 연락처·회의록·확정 전 아이디어가 쌓이는 공간입니다 — 이 템플릿 저장소는 공개지만, 여러분의 팀 저장소는 항상 프라이빗으로 운영하고 공개는 프로젝트 종료 후 민감 정보를 정리한 뒤 결정하세요.
-2. `Project Hub/ONBOARDING.md` 순서대로 진행합니다: 팀장이 저장소를 준비하고(0단계), AI와 **킥오프 인터뷰**(`_system/KICKOFF_INTERVIEW.md`)로 공식 문서를 채운 뒤(1단계), 팀원들이 온보딩 PR로 합류하고(2단계), 첫 회의에서 팀 규범을 확정합니다(3단계).
-3. 클론한 폴더를 Claude Code·Codex 같은 AI 도구로 열면 `AGENTS.md`의 시작 게이트가 킥오프 인터뷰를 자동으로 시작합니다 — 첫 질문으로 팀의 작업 언어(한국어/영어 등)를 묻습니다. AI 없이 쓴다면 `Project Hub/HOME.md`, `_system/TEAM.md`, `_system/CURRENT_STATE.md`의 대괄호 내용을 직접 채웁니다.
-4. 자료는 `00 Inbox/`에, 팀원별 작업은 `member/<이름>-<작업>` 브랜치에 올립니다.
-5. 팀장/통합 책임자가 PR을 검토해 `integrate/<범위>-YYYY-MM-DD`로 모은 뒤 `main`에 반영합니다.
-
-## 구조
-
-```text
-Project Hub/HOME.md # 사람이든 AI든 시작하는 대시보드
-AGENTS.md            # AI/사람 공통 작업 규칙 + 킥오프 시작 게이트
-CLAUDE.md            # Claude Code용 진입점 (AGENTS.md를 임포트)
-_system/             # 현재 상태·결정·팀·용어·규칙 — 공식 기준점
-00 Inbox/            # 아직 정리하지 않은 원본과 접수 대장
-Project Hub/      # 저장소 지도 + 온보딩(ONBOARDING)·팀 가이드(TEAM-GUIDE)
-01 Meetings/         # 회의록
-02 Decisions/        # 확정된 ADR/결정
-03 Research/         # 조사와 PDF/PPT/Word의 Markdown 정리본
-04 Worklogs/         # 개인 작업 기록
-05 Tasks/            # 공식 할 일
-06 Team/             # 팀원별 담당과 AI 프롬프트
-07 Outputs/          # 기획서·데모·발표 등 산출물
-90 Archive/          # 종료된 작업
-99 Templates/        # 회의록·결정·리서치 양식
-```
-
-## AI에게 이렇게 요청하세요
-
-```text
-이 저장소를 읽고 현재 프로젝트 맥락을 파악해줘.
-읽는 순서는 Project Hub/HOME.md → AGENTS.md → _system/CURRENT_STATE.md →
-_system/DECISION_LOG.md → 요청과 직접 관련 있는 근거 문서야.
-
-새 자료는 원본을 보관한 채 Markdown으로 정리하고,
-확정된 내용은 결정 로그와 현재 상태에 반영할 항목을 제안해줘.
-결정되지 않은 내용은 추측하지 말고 질문으로 남겨줘.
-```
-
-## NotebookLM으로 팀 브리핑·Q&A 만들기
-
-Context Hippo는 GitHub에서 NotebookLM으로 자동 동기화한다고 약속하지 않습니다. 대신 현재 결정과 변경만 담은, 사람이 검토 후 업로드하는 **NotebookLM Handoff 패키지**를 만들도록 돕습니다.
-
-- 처음 사용한다면: [`06 Team/NOTEBOOKLM-HANDOFF.md`](06%20Team/NOTEBOOKLM-HANDOFF.md)
-- 바로 만들려면: [`99 Templates/notebooklm-handoff.md`](99%20Templates/notebooklm-handoff.md)를 `07 Outputs/`에 복사
-- Handoff 파일 안에 팀 브리핑·슬라이드 초안·온보딩/Q&A·의사결정 검토용 프롬프트가 함께 있습니다. 별도 프롬프트 목록을 찾을 필요가 없습니다.
-
-## 원본과 Markdown을 함께 보관하기
-
-PDF·PPT·Word·회의 녹음은 해당 폴더의 `_raw/`에 원본으로 보관합니다. MarkItDown 같은 도구로 추출·정리한 `.md`는 같은 폴더 바로 아래에 둡니다. 정리본 첫 줄에는 원본 경로를 적습니다:
-
-```md
-> Origin: _raw/interview-notes.pdf
-```
-
-## 중요한 한계
-
-이 템플릿의 문서는 운영 기준입니다. `main` 보호와 required review는 GitHub 저장소 Settings에서 별도로 켜야 실제 권한 제어가 됩니다. 서버측 강제 장치 3종(branch protection·CODEOWNERS·guard CI), 실행 명령어, 그리고 무료 플랜 + 비공개 저장소를 위한 폴백(CI 신호 모드)은 `_system/GOVERNANCE.md`에 정리되어 있습니다.
-
-## License
-
-[MIT](LICENSE)
+## 규칙
+- 새 파일을 만들기 전, 이 표에서 맞는 위치를 확인합니다.
+- 공유 파일을 옮기면 `HOME.md`와 이 지도를 함께 갱신합니다.
+- 원본은 삭제하지 말고 해당 폴더의 `_raw/`에 보관합니다.

--- a/Project Hub/README.md
+++ b/Project Hub/README.md
@@ -1,5 +1,7 @@
 # Project Hub — Map of the repository
 
+<p><b>English</b> · <a href="README.ko.md">한국어</a></p>
+
 > `HOME.md` tells you **what to do right now**; this file tells you **where things live**.
 > This folder also holds the two human guides: `ONBOARDING.md` (getting started) and `TEAM-GUIDE.md` (everyday use without Git knowledge).
 

--- a/Project Hub/TEAM-GUIDE.md
+++ b/Project Hub/TEAM-GUIDE.md
@@ -10,7 +10,7 @@
 1. Create a `member/<name>-<task>` branch.
 2. Meeting notes go to `01 Meetings/`, research to `03 Research/`, personal notes to `04 Worklogs/`, deliverables to `07 Outputs/`.
 3. Write commit messages that say what you did and where the original lives.
-4. Open a PR and request review from the integrator.
+4. Open a PR and request integration. In team mode, request review from the integrator; in the default single-writer mode, the owner verifies the PR scope and CI before merging.
 
 ## Files you must not edit directly
 `HOME.md`, `AGENTS.md`, `CLAUDE.md`, `ONBOARDING.md`, `TEAM-GUIDE.md`, `_system/`, `02 Decisions/`, `05 Tasks/` are the team's official baseline. If a change is needed, explain why in a PR and request integration.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,91 @@
+# Context Hippo 🦛
+
+<p align="center">
+  <img src="assets/context-hippo-hero.png" alt="입을 크게 벌린 검은 하마 — Context Hippo 마크" width="380" />
+</p>
+
+<p align="center"><a href="README.md">English</a> · <b>한국어</b></p>
+
+팀의 흩어진 대화·회의·링크·문서를 받아, 사람과 AI가 함께 읽을 수 있는 **공유 맥락으로 소화하는** Obsidian + GitHub 템플릿입니다.
+
+Context Hippo는 자동으로 모든 자료를 처리하는 서비스가 아닙니다. 대신 원본을 어디에 넣고, 무엇을 Markdown으로 정리하며, 어떤 내용을 공식 결정과 현재 상태로 남길지 정합니다. 사람과 AI는 그 규칙을 함께 읽고 같은 프로젝트 맥락에서 작업합니다.
+
+> 이 문서는 한국어 안내판입니다. 저장소의 기준 문서는 영어(`README.md` 및 각 폴더 문서)이며, 내용이 다르면 영어판이 우선합니다. 킥오프 인터뷰에서 작업 언어로 한국어를 선택하면 AI가 만드는 노트·요약은 모두 한국어로 작성됩니다.
+
+## 작동 방식
+
+### 1. Capture — 원본을 모읍니다
+회의 전사, 링크, PDF·PPT·Word, 사진, 메모처럼 아직 정리되지 않은 것은 `00 Inbox/`에 넣습니다. 원본은 각 작업 폴더의 `_raw/`에 보관합니다.
+
+### 2. Digest — 읽을 수 있는 Markdown으로 소화합니다
+사람 또는 AI가 원본을 Markdown 노트로 정리하고, 내용의 성격에 따라 회의·리서치·작업 로그·산출물 폴더로 옮깁니다. 정리본은 항상 원본 위치를 가리킵니다.
+
+### 3. Decide — 공식 맥락을 갱신합니다
+확정된 선택은 `02 Decisions/`와 `_system/DECISION_LOG.md`에, 지금 진행 중인 일과 막힌 일은 `_system/CURRENT_STATE.md`에 남깁니다. 이 파일들이 팀의 공식 기준점입니다.
+
+### 4. Reuse — 다음 사람과 AI가 바로 이어받습니다
+새 팀원과 AI는 `Project Hub/HOME.md`부터 읽습니다. 볼트 전체를 훑지 않고도 현재 목표·결정·규칙·다음 행동을 파악한 뒤, 필요한 근거만 더 읽을 수 있습니다.
+
+## 시작하기
+
+1. 이 저장소를 **Use this template**으로 복제하되, 팀 저장소는 **반드시 Private**으로 만듭니다. 연락처·회의록·확정 전 아이디어가 쌓이는 공간입니다 — 이 템플릿 저장소는 공개지만, 여러분의 팀 저장소는 항상 프라이빗으로 운영하고 공개는 프로젝트 종료 후 민감 정보를 정리한 뒤 결정하세요.
+2. `Project Hub/ONBOARDING.md` 순서대로 진행합니다: 팀장이 저장소를 준비하고(0단계), AI와 **킥오프 인터뷰**(`_system/KICKOFF_INTERVIEW.md`)로 공식 문서를 채운 뒤(1단계), 팀원들이 온보딩 PR로 합류하고(2단계), 첫 회의에서 팀 규범을 확정합니다(3단계).
+3. 클론한 폴더를 Claude Code·Codex 같은 AI 도구로 열면 `AGENTS.md`의 시작 게이트가 킥오프 인터뷰를 자동으로 시작합니다 — 첫 질문으로 팀의 작업 언어(한국어/영어 등)를 묻습니다. AI 없이 쓴다면 `Project Hub/HOME.md`, `_system/TEAM.md`, `_system/CURRENT_STATE.md`의 대괄호 내용을 직접 채웁니다.
+4. 자료는 `00 Inbox/`에, 팀원별 작업은 `member/<이름>-<작업>` 브랜치에 올립니다.
+5. 팀장/통합 책임자가 PR을 검토해 `integrate/<범위>-YYYY-MM-DD`로 모은 뒤 `main`에 반영합니다.
+
+## 구조
+
+```text
+Project Hub/HOME.md # 사람이든 AI든 시작하는 대시보드
+AGENTS.md            # AI/사람 공통 작업 규칙 + 킥오프 시작 게이트
+CLAUDE.md            # Claude Code용 진입점 (AGENTS.md를 임포트)
+_system/             # 현재 상태·결정·팀·용어·규칙 — 공식 기준점
+00 Inbox/            # 아직 정리하지 않은 원본과 접수 대장
+Project Hub/      # 저장소 지도 + 온보딩(ONBOARDING)·팀 가이드(TEAM-GUIDE)
+01 Meetings/         # 회의록
+02 Decisions/        # 확정된 ADR/결정
+03 Research/         # 조사와 PDF/PPT/Word의 Markdown 정리본
+04 Worklogs/         # 개인 작업 기록
+05 Tasks/            # 공식 할 일
+06 Team/             # 팀원별 담당과 AI 프롬프트
+07 Outputs/          # 기획서·데모·발표 등 산출물
+90 Archive/          # 종료된 작업
+99 Templates/        # 회의록·결정·리서치 양식
+```
+
+## AI에게 이렇게 요청하세요
+
+```text
+이 저장소를 읽고 현재 프로젝트 맥락을 파악해줘.
+읽는 순서는 Project Hub/HOME.md → AGENTS.md → _system/CURRENT_STATE.md →
+_system/DECISION_LOG.md → 요청과 직접 관련 있는 근거 문서야.
+
+새 자료는 원본을 보관한 채 Markdown으로 정리하고,
+확정된 내용은 결정 로그와 현재 상태에 반영할 항목을 제안해줘.
+결정되지 않은 내용은 추측하지 말고 질문으로 남겨줘.
+```
+
+## NotebookLM으로 팀 브리핑·Q&A 만들기
+
+Context Hippo는 GitHub에서 NotebookLM으로 자동 동기화한다고 약속하지 않습니다. 대신 현재 결정과 변경만 담은, 사람이 검토 후 업로드하는 **NotebookLM Handoff 패키지**를 만들도록 돕습니다.
+
+- 처음 사용한다면: [`06 Team/NOTEBOOKLM-HANDOFF.md`](06%20Team/NOTEBOOKLM-HANDOFF.md)
+- 바로 만들려면: [`99 Templates/notebooklm-handoff.md`](99%20Templates/notebooklm-handoff.md)를 `07 Outputs/`에 복사
+- Handoff 파일 안에 팀 브리핑·슬라이드 초안·온보딩/Q&A·의사결정 검토용 프롬프트가 함께 있습니다. 별도 프롬프트 목록을 찾을 필요가 없습니다.
+
+## 원본과 Markdown을 함께 보관하기
+
+PDF·PPT·Word·회의 녹음은 해당 폴더의 `_raw/`에 원본으로 보관합니다. MarkItDown 같은 도구로 추출·정리한 `.md`는 같은 폴더 바로 아래에 둡니다. 정리본 첫 줄에는 원본 경로를 적습니다:
+
+```md
+> Origin: _raw/interview-notes.pdf
+```
+
+## 거버넌스 모드
+
+이 템플릿은 기본적으로 **단독 작성자 모드**로 시작합니다. 워크플로는 CI 신호를 제공하지만, review와 required check는 강제 머지 장치로 켜지지 않습니다. 포크하거나 다인 팀으로 전환하기 전에는 PR 요구, Code Owners review, required check를 켤지 명시적으로 결정하세요. 두 모드와 정확한 설정 방법은 `_system/GOVERNANCE.md`에 정리되어 있습니다.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/context-hippo-hero.png" alt="Context Hippo mark — a black hippo with its mouth wide open" width="380" />
 </p>
 
-<p align="center"><b>English</b> · <a href="00%20Project%20Hub/README.ko.md">한국어</a></p>
+<p align="center"><b>English</b> · <a href="README.ko.md">한국어</a></p>
 
 An Obsidian + GitHub template that takes your team's scattered chats, meetings, links, and documents and **digests them into shared context** that humans and AI read together.
 
@@ -80,9 +80,9 @@ Store PDF/PPT/Word files and meeting recordings as originals in the folder's `_r
 > Origin: _raw/interview-notes.pdf
 ```
 
-## An important limitation
+## Governance mode
 
-The documents in this template are an operating baseline. `main` branch protection and required reviews must be enabled separately in the repository Settings on GitHub to become real access control. `_system/GOVERNANCE.md` documents the three server-side gates (branch protection, CODEOWNERS, guard CI), the exact commands, and the free-plan fallback (CI signal mode) for private repositories.
+This template starts in **single-writer mode**: its workflows provide CI signals, while reviews and required checks are not enabled as hard merge gates. Before a fork or a move to a multi-writer team, explicitly decide whether to enable PR requirements, Code Owners review, and required checks. `_system/GOVERNANCE.md` documents both modes and the exact configuration.
 
 ## License
 

--- a/_system/GOVERNANCE.md
+++ b/_system/GOVERNANCE.md
@@ -5,24 +5,30 @@
 > Sister document: [INTEGRATION_RULES.md](INTEGRATION_RULES.md) — the protected-file list and the integration-branch (`integrate/*`) procedure.
 > **Role split:** INTEGRATION_RULES + the `protected-paths` CI answer *which files* are protected (branch-based; `integrate/*` passes). This document + the `guard-structure` CI answer *who* — owner vs non-owner — may land what on `main` (author-based; owners pass). Integration-branch PRs are opened by an owner, so they pass both checks.
 
+## Operating mode — choose deliberately
+
+The template starts in **single-writer mode**: PRs and CI are used for traceability and verification, but GitHub reviews and required status checks are not configured as hard merge gates. This is intentional: a sole owner cannot approve their own PR.
+
+Before a fork or a transition to multiple writers, the owner must explicitly choose **team mode**. Team mode enables branch protection, Code Owners review, and required CI as described below. Do not describe those controls as active until they are actually configured in GitHub Settings.
+
 ## First, the technical limits (know them precisely)
 
 - **"Did AI or a human make this commit" cannot be distinguished.** Git's author/committer fields and `Co-Authored-By` trailers are plain text anyone can set — forgeable. "Detect and block human commits" is impossible in principle.
-- So enforcement works **not by "who typed it" but by path + approval + PR author**. The PR author is GitHub-authenticated and cannot be forged.
+- So enforcement works **not by "who typed it" but by path + authenticated PR author and, in team mode, approval**. The PR author is GitHub-authenticated and cannot be forged.
 - **Client-side hooks (pre-commit/pre-push) are not walls** — they don't come along with a clone and are bypassed with `--no-verify`. They can help; they cannot enforce. Real enforcement is server-side on GitHub only.
 
 ## Enforcement scope
 
 - **Personal branches (`member/*`) = free.** This is where AI works and where humans upload into `00 Inbox` freely.
-- **`main` = locked (the canonical context).** Only material organized and verified on personal branches enters, through an owner-approved PR.
+- **`main` = canonical context.** Only material organized and verified on personal branches enters through the agreed integration flow. In team mode, this is an owner-approved PR.
 
-## The three gates (all server-side = not bypassable)
+## The three team-mode gates (server-side once enabled)
 
 1. **Branch protection on `main`** — no direct pushes, PR required, ≥1 approval, "Require review from Code Owners" ON, and the `guard` check marked **required**.
 2. **CODEOWNERS** (`.github/CODEOWNERS`) — every path owned by the owner(s), so no main PR merges without owner approval. Replace `{{OWNER_HANDLE}}` with the real handle(s); a wrong handle silently disables the gate.
 3. **guard-structure Action** (`.github/workflows/guard-structure.yml`) — if a main PR's author is not in the OWNERS list and the PR touches anything outside `00 Inbox/`, the check **fails automatically**. It only becomes a wall once marked "required" in branch protection.
 
-## What the owner enables once (Settings or gh)
+## What the owner enables for team mode (Settings or gh)
 
 > **Plan caveat (measured in practice):** on the **free plan, branch protection on a *private* repository returns 403** ("Upgrade to GitHub Pro or make this repository public"). Your options:
 >
@@ -43,14 +49,14 @@ gh api -X PUT "repos/{{OWNER_HANDLE}}/{{REPO}}/branches/main/protection" \
 # (Confirm the check's context name in the Checks tab after the Action has run once — usually "guard".)
 ```
 
-> ⚠️ **You cannot approve your own PR.** With a single owner, that owner's PRs would be stuck. Either keep two owners who approve each other, or leave `enforce_admins=false` so an admin can bypass when needed.
+> ⚠️ **You cannot approve your own PR.** With a single owner, keep the default single-writer mode and self-verify PR scope and CI before merging. For team mode, use at least two owners who can approve each other; `enforce_admins=false` is an emergency bypass, not a routine workflow.
 
 ## The daily flow (what AI must follow — also stated in AGENTS.md)
 
 1. A human uploads originals into `00 Inbox` on a personal branch.
 2. AI runs the four Inbox steps (AGENTS.md → "Inbox processing"): digest into 01–07, move the original to the destination `_raw/`, point the origin link at the final location, empty the Inbox — all in one commit.
 3. **AI confirms with the branch's human before pushing.**
-4. `main` changes land only via owner-approved PRs. Structure and context changes are filtered here.
+4. In single-writer mode, the owner verifies PR scope and CI before merging. In team mode, `main` changes land only via owner-approved PRs. Structure and context changes are filtered here.
 
 ## Reverting
 

--- a/_system/INTEGRATION_RULES.md
+++ b/_system/INTEGRATION_RULES.md
@@ -3,8 +3,8 @@
 | Kind | Name | Can do | Cannot do |
 |---|---|---|---|
 | Member work branch | `member/<name>-<task>` | originals, meeting notes, research, worklogs, outputs | change official state/decisions/priorities |
-| Integration branch | `integrate/<scope>-YYYY-MM-DD` | combine PRs, update protected files, resolve conflicts | merge to main without lead approval |
-| `main` | official baseline | receive reviewed PRs | direct work / direct pushes |
+| Integration branch | `integrate/<scope>-YYYY-MM-DD` | combine PRs, update protected files, resolve conflicts | merge to main without the mode-appropriate verification |
+| `main` | official baseline | receive reviewed PRs | direct work outside the agreed integration flow |
 
 ## Protected files
 `README.md`, `AGENTS.md`, `CLAUDE.md`, `Project Hub/**` (dashboard, Korean guide, repo map + onboarding/team guides), `_system/**`, `02 Decisions/**`, `05 Tasks/**`, `.github/**`, `scripts/**`, and each folder's `README.md` are changed only by the integrator.
@@ -16,6 +16,6 @@ Enforcement: `scripts/verify-protected-paths.sh` implements this list and runs a
 2. The PR states its scope, sources, and whether it conflicts with existing decisions.
 3. The integrator reviews and asks questions where needed.
 4. On `integrate/...`, update `CURRENT_STATE`, `DECISION_LOG`, ADRs, and official tasks together.
-5. The lead approves the final PR into `main`.
+5. In team mode, the lead approves the final PR into `main`. In the default single-writer mode, the owner verifies the PR scope and CI before merging.
 
-> Enable main branch protection and required reviews in GitHub Settings to make this real access control.
+> The template defaults to single-writer mode: reviews and required checks are not configured as hard gates. Before a fork or a multi-writer transition, decide whether to enable them in GitHub Settings; see [GOVERNANCE.md](GOVERNANCE.md).


### PR DESCRIPTION
## Changes
- English stays the default; root Korean overview is now `README.ko.md`
- Add a Korean `Project Hub` map and cross-links
- Repair all links affected by the `Project Hub/` move
- Document single-writer mode accurately; team-mode protections are an explicit future decision

## Verification
- Markdown local-link validation passed
- No tracked `K7`, `Miri`, or `미리` reference exists in main or this branch